### PR TITLE
pull transactions every 15mins

### DIFF
--- a/src/components/common/overall-layout/wallet-data-loader.tsx
+++ b/src/components/common/overall-layout/wallet-data-loader.tsx
@@ -45,7 +45,7 @@ export default function WalletDataLoader() {
       const blockchainProvider = getProvider(network);
 
       for (let i = 1; i <= maxPage; i++) {
-        let transactions: TxInfo[] = await blockchainProvider.get(
+        const transactions: TxInfo[] = await blockchainProvider.get(
           `/addresses/${appWallet.address}/transactions?page=${i}&order=desc`,
         );
 

--- a/src/components/pages/wallet/transactions/all-transactions.tsx
+++ b/src/components/pages/wallet/transactions/all-transactions.tsx
@@ -17,7 +17,6 @@ import { OnChainTransaction } from "@/types/transaction";
 import { useWalletsStore } from "@/lib/zustand/wallets";
 import { Transaction } from "@prisma/client";
 import { Badge } from "@/components/ui/badge";
-import { NUMBER_OF_TRANSACTIONS } from "@/config/wallet";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -45,7 +44,7 @@ export default function AllTransactions({ appWallet }: { appWallet: Wallet }) {
   return (
     <CardUI
       title="Transactions"
-      description={`Latest ${NUMBER_OF_TRANSACTIONS} transactions`}
+      description={``}
       headerDom={
         <LinkCardanoscan
           url={`address/${appWallet.address}`}
@@ -102,10 +101,13 @@ function TransactionRow({
         <div className="flex gap-2 text-sm text-muted-foreground md:inline">
           <LinkCardanoscan
             url={`transaction/${transaction.hash}`}
-            className="flex flex-col w-44 gap-1"
+            className="flex w-44 flex-col gap-1"
           >
             <span className="flex gap-1">
-              <span>{transaction.hash.substring(0, 6)}...{transaction.hash.slice(-6)}</span>
+              <span>
+                {transaction.hash.substring(0, 6)}...
+                {transaction.hash.slice(-6)}
+              </span>
               <ArrowUpRight className="h-3 w-3" />
             </span>
             <span className="text-xs">
@@ -200,7 +202,7 @@ function RowAction({
     const allTxInputsFromSameAddress = transaction.inputs.every(
       (input) => input.address === transaction.inputs[0]!.address,
     );
-    
+
     if (allTxInputsFromSameAddress) {
       const txBuilder = getTxBuilder(network);
 

--- a/src/config/wallet.ts
+++ b/src/config/wallet.ts
@@ -1,1 +1,2 @@
-export const NUMBER_OF_TRANSACTIONS = 20;
+// export const NUMBER_OF_TRANSACTIONS = 20;
+export const LAST_UPDATED_THRESHOLD = 1000 * 60 * 15;

--- a/src/lib/zustand/wallets.ts
+++ b/src/lib/zustand/wallets.ts
@@ -44,6 +44,8 @@ interface State {
     walletId: string,
     transactions: OnChainTransaction[],
   ) => void;
+  walletLastUpdated: { [walletId: string]: number };
+  setWalletLastUpdated: (walletId: string, timestamp: number) => void;
   drepInfo: BlockfrostDrepInfo | undefined;
   setDrepInfo: (drepInfo: BlockfrostDrepInfo) => void;
   drepRegistered: boolean;
@@ -61,6 +63,14 @@ export const useWalletsStore = create<State>()(
           walletTransactions: {
             ...get().walletTransactions,
             [walletId]: transactions,
+          },
+        }),
+      walletLastUpdated: {},
+      setWalletLastUpdated: (walletId, timestamp) =>
+        set({
+          walletLastUpdated: {
+            ...get().walletLastUpdated,
+            [walletId]: timestamp,
           },
         }),
       drepInfo: undefined,


### PR DESCRIPTION
Currently the pulling of wallet's transactions is in `src/components/common/overall-layout/wallet-data-loader.tsx`, and its conditions to pull updated transactions data are:
- `if (appWallet && walletsUtxos[appWallet?.id] === undefined)`
- user click the top-right "refresh" button

This resulted in the transactions not updated automatically (via useEffect) if there are existing transactions in cache. Having cache is superb user experience as its removes the empty screen (so this should remain and not be removed). However, it is not obvious that they have to click the refresh button to fetch new transactions.