### PR TITLE
Feature/cardano native assets

### DIFF
--- a/src/components/common/cardano-objects/connect-wallet.tsx
+++ b/src/components/common/cardano-objects/connect-wallet.tsx
@@ -55,7 +55,7 @@ export default function ConnectWallet() {
       if (!wallet) return;
       try {
         const assets = await wallet.getBalance();
-        const provider = getProvider(1);
+        const provider = getProvider(await wallet.getNetworkId());
         const userAssets: Asset[] = [];
         if (assets) {
           for (const asset of assets) {

--- a/src/components/common/cardano-objects/connect-wallet.tsx
+++ b/src/components/common/cardano-objects/connect-wallet.tsx
@@ -54,20 +54,26 @@ export default function ConnectWallet() {
     async function lookupWalletAssets() {
       if (!wallet) return;
       try {
-        const assets = await wallet.getAssets();
+        const assets = await wallet.getBalance();
         const provider = getProvider(1);
+        const userAssets: Asset[] = [];
         if (assets) {
-          setUserAssets(assets);
           for (const asset of assets) {
+            userAssets.push({
+              unit: asset.unit,
+              quantity: asset.quantity,
+            });
+            if (asset.unit === "lovelace") continue;
             const assetInfo = await provider.get(`/assets/${asset.unit}`);
             setUserAssetMetadata(
-              asset.policyId,
+              asset.unit,
               assetInfo?.metadata?.name ||
                 assetInfo?.onchain_metadata?.name ||
                 asset.unit,
               assetInfo?.metadata?.decimals || 0,
             );
           }
+          setUserAssets(userAssets);
         }
       } catch (error) {
         console.error("Error looking up wallet assets:", error);

--- a/src/components/common/cardano-objects/connect-wallet.tsx
+++ b/src/components/common/cardano-objects/connect-wallet.tsx
@@ -28,6 +28,7 @@ export default function ConnectWallet() {
 
   const wallets = useWalletList();
   const { connect, connected, wallet, name } = useWallet();
+  const network = useSiteStore((state) => state.network);
 
   async function connectWallet(walletId: string) {
     setPastWallet(walletId);

--- a/src/components/common/overall-layout/layout.tsx
+++ b/src/components/common/overall-layout/layout.tsx
@@ -85,8 +85,6 @@ export default function RootLayout({
   const pageIsPublic = publicRoutes.includes(router.pathname);
   const isLoggedIn = !!user;
 
-  
-
   return (
     <div className="grid h-screen w-full overflow-hidden md:grid-cols-[220px_1fr] lg:grid-cols-[280px_1fr]">
       {isLoading && <Loading />}
@@ -112,7 +110,6 @@ export default function RootLayout({
       <div className="flex h-screen flex-col">
         <header className="pointer-events-auto relative z-10 border-b bg-muted/40 px-4 lg:px-6">
           <div className="flex h-14 items-center gap-4 lg:h-[60px]">
-            
             {/* Wallet selection + breadcrumb row */}
             {isLoggedIn && (
               <div className="border-t border-border">

--- a/src/components/common/overall-layout/menus/wallet.tsx
+++ b/src/components/common/overall-layout/menus/wallet.tsx
@@ -1,4 +1,4 @@
-import { Info, List } from "lucide-react";
+import { Banknote, Info, List } from "lucide-react";
 import { useRouter } from "next/router";
 import MenuLink from "./menu-link";
 import usePendingTransactions from "@/hooks/usePendingTransactions";
@@ -11,11 +11,10 @@ export default function MenuWallet() {
   const baseUrl = `/wallets/${router.query.wallet as string | undefined}/`;
   const { wallets } = useUserWallets();
   const { transactions } = usePendingTransactions();
-  if(!wallets)return;
+  if (!wallets) return;
   return (
     <nav className="grid h-full items-start px-2 text-sm font-medium lg:px-4">
       <div className="grid items-start">
-
         <MenuLink
           href={`${baseUrl}transactions`}
           className={
@@ -33,6 +32,15 @@ export default function MenuWallet() {
               </Badge>
             )}
           </div>
+        </MenuLink>
+        <MenuLink
+          href={`${baseUrl}balance`}
+          className={
+            router.pathname == "/wallets/[wallet]/balance" ? "text-white" : ""
+          }
+        >
+          <Banknote className="h-4 w-4" />
+          Balance
         </MenuLink>
         <MenuLink
           href={`${baseUrl}chat`}

--- a/src/components/common/overall-layout/wallet-data-loader.tsx
+++ b/src/components/common/overall-layout/wallet-data-loader.tsx
@@ -8,6 +8,7 @@ import { api } from "@/utils/api";
 import { OnChainTransaction, TxInfo } from "@/types/transaction";
 import { useSiteStore } from "@/lib/zustand/site";
 import { LAST_UPDATED_THRESHOLD } from "@/config/wallet";
+import { Asset } from "@meshsdk/core";
 
 export default function WalletDataLoader() {
   const { appWallet } = useAppWallet();
@@ -20,6 +21,10 @@ export default function WalletDataLoader() {
   const walletLastUpdated = useWalletsStore((state) => state.walletLastUpdated);
   const setWalletLastUpdated = useWalletsStore(
     (state) => state.setWalletLastUpdated,
+  );
+  const setWalletAssets = useWalletsStore((state) => state.setWalletAssets);
+  const setWalletAssetMetadata = useWalletsStore(
+    (state) => state.setWalletAssetMetadata,
   );
   const fetchingTransactions = useRef(false);
 
@@ -71,6 +76,40 @@ export default function WalletDataLoader() {
     }
   }
 
+  async function getWalletAssets() {
+    try {
+      const blockchainProvider = getProvider(network);
+      const assets = await blockchainProvider.get(
+        `/addresses/${appWallet?.address}/`,
+      );
+      const walletAssets: Asset[] = [];
+      console.log("blockfrost assets", assets);
+      if (assets.amount) {
+        for (const asset of assets.amount) {
+          walletAssets.push({
+            unit: asset.unit,
+            quantity: asset.quantity,
+          });
+          if (asset.unit === "lovelace") continue;
+          const assetInfo = await blockchainProvider.get(
+            `/assets/${asset.unit}`,
+          );
+          setWalletAssetMetadata(
+            asset.unit,
+            assetInfo?.metadata?.name ||
+              assetInfo?.onchain_metadata?.name ||
+              asset.unit,
+            assetInfo?.metadata?.decimals || 0,
+          );
+        }
+        console.log("wallet assets", walletAssets, assets);
+        setWalletAssets(walletAssets);
+      }
+    } catch (error) {
+      console.error("Error looking up wallet assets:", error);
+    }
+  }
+
   async function refreshWallet() {
     if (fetchingTransactions.current) return;
 
@@ -78,6 +117,7 @@ export default function WalletDataLoader() {
     setLoading(true);
     await fetchUtxos();
     await getTransactionsOnChain();
+    await getWalletAssets();
     void ctx.transaction.getPendingTransactions.invalidate();
     void ctx.transaction.getAllTransactions.invalidate();
     setRandomState();

--- a/src/components/common/overall-layout/wallet-data-loader.tsx
+++ b/src/components/common/overall-layout/wallet-data-loader.tsx
@@ -83,7 +83,6 @@ export default function WalletDataLoader() {
         `/addresses/${appWallet?.address}/`,
       );
       const walletAssets: Asset[] = [];
-      console.log("blockfrost assets", assets);
       if (assets.amount) {
         for (const asset of assets.amount) {
           walletAssets.push({
@@ -100,6 +99,10 @@ export default function WalletDataLoader() {
               assetInfo?.onchain_metadata?.name ||
               asset.unit,
             assetInfo?.metadata?.decimals || 0,
+            assetInfo?.metadata?.logo || "",
+            assetInfo?.metadata?.ticker ||
+              assetInfo?.onchain_metadata?.ticker ||
+              "",
           );
         }
         console.log("wallet assets", walletAssets, assets);

--- a/src/components/pages/wallet/balance/index.tsx
+++ b/src/components/pages/wallet/balance/index.tsx
@@ -1,0 +1,16 @@
+import useAppWallet from "@/hooks/useAppWallet";
+import FullBalance from "./full-balance";
+
+export default function PageTransactions() {
+  const { appWallet } = useAppWallet();
+
+  if (appWallet === undefined) return <></>;
+
+  return (
+    <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <FullBalance appWallet={appWallet} />
+      </div>
+    </main>
+  );
+}

--- a/src/components/pages/wallet/new-transaction/deposit/index.tsx
+++ b/src/components/pages/wallet/new-transaction/deposit/index.tsx
@@ -2,14 +2,7 @@ import SectionTitle from "@/components/common/section-title";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import useAppWallet from "@/hooks/useAppWallet";
-import {
-  deserializePoolId,
-  keepRelevant,
-  type Quantity,
-  resolveScriptHash,
-  serializeRewardAddress,
-  type Unit,
-} from "@meshsdk/core";
+import { keepRelevant, type Quantity, type Unit } from "@meshsdk/core";
 import { useWallet } from "@meshsdk/react";
 import { Loader, PlusCircle, Send, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -31,7 +24,6 @@ import { ToastAction } from "@/components/ui/toast";
 import { useToast } from "@/hooks/use-toast";
 import { useRouter } from "next/router";
 import { cn } from "@/lib/utils";
-import { set } from "idb-keyval";
 
 export default function PageNewTransaction() {
   const { connected, wallet } = useWallet();
@@ -170,10 +162,8 @@ export default function PageNewTransaction() {
           );
         }
       }
-      console.log(assetMap);
 
       selectedUtxos = keepRelevant(assetMap, utxos);
-      console.log(selectedUtxos);
 
       if (selectedUtxos.length === 0) {
         setError(
@@ -191,15 +181,7 @@ export default function PageNewTransaction() {
           utxo.output.amount,
           utxo.output.address,
         );
-
-        console.log("tx In: ", {
-          txHash: utxo.input.txHash,
-          outputIndex: utxo.input.outputIndex,
-          amount: utxo.output.amount,
-          address: utxo.output.address,
-        });
       }
-      console.log(txBuilder);
       for (const output of outputs) {
         txBuilder.txOut(output.address, [
           {
@@ -207,12 +189,7 @@ export default function PageNewTransaction() {
             quantity: output.amount,
           },
         ]);
-        console.log("tx Out: ", `${output.address}`, {
-          quantity: output.amount,
-          unit: output.unit,
-        });
       }
-      console.log(txBuilder);
       const unsignedTx = await txBuilder.changeAddress(userAddress).complete();
       const signedTx = await wallet.signTx(unsignedTx);
       const txHash = await wallet.submitTx(signedTx);

--- a/src/components/pages/wallet/new-transaction/deposit/index.tsx
+++ b/src/components/pages/wallet/new-transaction/deposit/index.tsx
@@ -148,13 +148,20 @@ export default function PageNewTransaction() {
 
       for (let i = 0; i < UTxoCount; i++) {
         if (address && address.startsWith("addr") && address.length > 0) {
-          const unit = assets[i] === "ADA" ? "lovelace" : assets[i]!;
+          const rawUnit = assets[i];
+          // Default to 'lovelace' if rawUnit is undefined or if it's 'ADA'
+          const unit = rawUnit
+            ? rawUnit === "ADA"
+              ? "lovelace"
+              : rawUnit
+            : "lovelace";
           const assetMetadata = userAssetMetadata[unit];
           const multiplier =
             unit === "lovelace"
               ? 1000000
               : Math.pow(10, assetMetadata?.decimals ?? 0);
-          const thisAmount = parseFloat(amounts[i]!) * multiplier;
+          const parsedAmount = parseFloat(amounts[i]!) || 0;
+          const thisAmount = parsedAmount * multiplier;
           outputs.push({
             address: address,
             unit: unit,
@@ -166,7 +173,6 @@ export default function PageNewTransaction() {
           );
         }
       }
-
       selectedUtxos = keepRelevant(assetMap, utxos);
 
       if (selectedUtxos.length === 0) {

--- a/src/components/pages/wallet/new-transaction/deposit/index.tsx
+++ b/src/components/pages/wallet/new-transaction/deposit/index.tsx
@@ -149,7 +149,11 @@ export default function PageNewTransaction() {
       for (let i = 0; i < UTxoCount; i++) {
         if (address && address.startsWith("addr") && address.length > 0) {
           const unit = assets[i] === "ADA" ? "lovelace" : assets[i]!;
-          const multiplier = unit === "lovelace" ? 1000000 : 1;
+          const assetMetadata = userAssetMetadata[unit];
+          const multiplier =
+            unit === "lovelace"
+              ? 1000000
+              : Math.pow(10, assetMetadata?.decimals ?? 0);
           const thisAmount = parseFloat(amounts[i]!) * multiplier;
           outputs.push({
             address: address,

--- a/src/components/pages/wallet/new-transaction/deposit/index.tsx
+++ b/src/components/pages/wallet/new-transaction/deposit/index.tsx
@@ -31,6 +31,7 @@ import { ToastAction } from "@/components/ui/toast";
 import { useToast } from "@/hooks/use-toast";
 import { useRouter } from "next/router";
 import { cn } from "@/lib/utils";
+import { set } from "idb-keyval";
 
 export default function PageNewTransaction() {
   const { connected, wallet } = useWallet();
@@ -86,6 +87,8 @@ export default function PageNewTransaction() {
         decimals: number;
       }
     > = {};
+
+    console.log("reconfiguring assets with amounts", assets, amounts);
 
     // reduce assets and amounts to Asset: Amount object
     for (let i = 0; i < assets.length; i++) {
@@ -239,6 +242,7 @@ export default function PageNewTransaction() {
   function addNewUTxO() {
     setUTxoCount(UTxoCount + 1);
     setAmounts([...amounts, "100"]);
+    setAssets([...assets, "ADA"]);
   }
 
   return (
@@ -436,9 +440,15 @@ function UTxORow({
           size="icon"
           variant="ghost"
           onClick={() => {
+            // remove amount
             const newAmounts = [...amounts];
             newAmounts.splice(index, 1);
             setAmounts(newAmounts);
+
+            // remove asset
+            const newAssets = [...assets];
+            newAssets.splice(index, 1);
+            setAssets(newAssets);
           }}
         >
           <X className="h-4 w-4" />

--- a/src/components/pages/wallet/new-transaction/utxoSelector.tsx
+++ b/src/components/pages/wallet/new-transaction/utxoSelector.tsx
@@ -14,6 +14,7 @@ import usePendingTransactions from "@/hooks/usePendingTransactions";
 import { Toggle } from "@/components/ui/toggle";
 import { UTxO } from "@meshsdk/core";
 import { useWalletsStore } from "@/lib/zustand/wallets";
+import { Button } from "@/components/ui/button";
 
 interface UTxOSelectorProps {
   appWallet: Wallet;
@@ -125,6 +126,22 @@ export default function UTxOSelector({
     );
   };
 
+  const handleToggleSelectAll = () => {
+    if (selectedUtxos.length > 0) {
+      setSelectedUtxos([]);
+    } else {
+      const freeUtxos = utxos.filter(
+        (utxo) =>
+          !blockedUtxos.some(
+            (bU) =>
+              bU.hash === utxo.input.txHash &&
+              bU.index === utxo.input.outputIndex,
+          ),
+      );
+      setSelectedUtxos(freeUtxos);
+    }
+  };
+
   return (
     <div>
       <Toggle
@@ -142,12 +159,26 @@ export default function UTxOSelector({
             <TableRow>
               <TableHead>Tx Index - Hash</TableHead>
               <TableHead>Outputs</TableHead>
-              <TableHead>Select</TableHead>
+              <TableHead style={{ width: '110px', textAlign: 'center' }}>
+                <Button
+                  onClick={handleToggleSelectAll}
+                  className="select-all-btn"
+                  style={{
+                    width: '110px',
+                    minWidth: '110px',
+                    maxWidth: '110px',
+                    display: 'block',
+                    whiteSpace: 'nowrap'
+                  }}
+                >
+                  {selectedUtxos.length > 0 ? "Deselect All" : "Select All"}
+                </Button>
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {utxos.map((utxo, index) => (
-              <TableRow key={index}>
+              <TableRow key={index} style={{ height: "50px" }}>
                 <TableCell className="truncate">
                   {utxo.input.outputIndex}-{utxo.input.txHash.slice(0, 10)}...
                   {utxo.input.txHash.slice(-10)}
@@ -169,20 +200,18 @@ export default function UTxOSelector({
                                 ? `$${assetMetadata?.ticker}`
                                 : unit.unit;
                           return (
-                            <>
-                              <span key={unit.unit}>
-                                {j > 0 && ", "}
-                                {unit.quantity / Math.pow(10, decimals)}{" "}
-                                {assetName}
-                              </span>
-                            </>
+                            <span key={unit.unit}>
+                              {j > 0 && ", "}
+                              {unit.quantity / Math.pow(10, decimals)}{" "}
+                              {assetName}
+                            </span>
                           );
                         },
                       )}
                     </div>
                   </div>
                 </TableCell>
-                <TableCell>
+                <TableCell style={{ width: '100px', textAlign: 'center' }}>
                   {blockedUtxos.some(
                     (bU) =>
                       bU.hash === utxo.input.txHash &&

--- a/src/components/pages/wallet/transactions/all-transactions.tsx
+++ b/src/components/pages/wallet/transactions/all-transactions.tsx
@@ -140,7 +140,6 @@ function TransactionRow({
             (input: any) => input.address === appWallet.address,
           );
           if (isSpend && output.address != appWallet.address) {
-            console.log("spending", output);
             return (
               <div key={i} className="flex gap-2">
                 <div className="text-red-400">

--- a/src/components/pages/wallet/transactions/all-transactions.tsx
+++ b/src/components/pages/wallet/transactions/all-transactions.tsx
@@ -105,6 +105,14 @@ function TransactionRow({
     }[]
   >([]);
 
+  const walletAssetMetadata = useWalletsStore(
+    (state) => state.walletAssetMetadata,
+  );
+  const walletAssets = useWalletsStore((state) => state.walletAssets);
+
+  console.log("app wallet metadata", walletAssetMetadata);
+  console.log("app wallet assets", walletAssets);
+
   useEffect(() => {
     const outputs: {
       unit: string;

--- a/src/components/pages/wallet/transactions/all-transactions.tsx
+++ b/src/components/pages/wallet/transactions/all-transactions.tsx
@@ -140,6 +140,7 @@ function TransactionRow({
             (input: any) => input.address === appWallet.address,
           );
           if (isSpend && output.address != appWallet.address) {
+            console.log("spending", output);
             return (
               <div key={i} className="flex gap-2">
                 <div className="text-red-400">
@@ -153,7 +154,9 @@ function TransactionRow({
                     const assetName =
                       unit.unit === "lovelace"
                         ? "₳"
-                        : (assetMetadata?.assetName ?? unit.unit);
+                        : assetMetadata?.ticker
+                          ? `$${assetMetadata?.ticker}`
+                          : unit.unit;
                     return (
                       <span key={unit.unit}>
                         {j > 0 && ", "}
@@ -181,7 +184,9 @@ function TransactionRow({
                     const assetName =
                       unit.unit === "lovelace"
                         ? "₳"
-                        : (assetMetadata?.assetName ?? unit.unit);
+                        : assetMetadata?.ticker
+                          ? `$${assetMetadata?.ticker}`
+                          : unit.unit;
                     return (
                       <span key={unit.unit}>
                         {j > 0 && ", "}

--- a/src/components/pages/wallet/transactions/all-transactions.tsx
+++ b/src/components/pages/wallet/transactions/all-transactions.tsx
@@ -26,6 +26,7 @@ import {
 import { useSiteStore } from "@/lib/zustand/site";
 import { getTxBuilder } from "@/components/common/cardano-objects/get-tx-builder";
 import useTransaction from "@/hooks/useTransaction";
+import { useEffect, useState } from "react";
 
 export default function AllTransactions({ appWallet }: { appWallet: Wallet }) {
   const { transactions: dbTransactions } = useAllTransactions({
@@ -95,6 +96,38 @@ function TransactionRow({
   appWallet: Wallet;
   dbTransaction?: Transaction;
 }) {
+  const [transactionOutputs, setTransactionOutputs] = useState<
+    {
+      unit: string;
+      quantity: number;
+      decimals: number;
+      assetName: string;
+    }[]
+  >([]);
+
+  useEffect(() => {
+    const outputs: {
+      unit: string;
+      quantity: number;
+      decimals: number;
+      assetName: string;
+    }[] = [];
+    transaction.outputs.map((output) => {
+      Object.values(output.amount).map((outputValue) => {
+        outputs.push({
+          unit: outputValue.unit,
+          quantity: Number(outputValue.quantity),
+          // decimals: userAssetMetadata[outputValue.unit]?.decimals ?? 0,
+          // assetName:
+          //   userAssetMetadata[outputValue.unit]?.assetName ?? outputValue.unit,
+          decimals: 0,
+          assetName: outputValue.unit,
+        });
+      });
+    });
+    setTransactionOutputs(outputs);
+  }, [transaction]);
+  console.log("transaction row", transactionOutputs);
   return (
     <TableRow style={{ backgroundColor: "none" }}>
       <TableCell>

--- a/src/components/pages/wallet/transactions/card-balance.tsx
+++ b/src/components/pages/wallet/transactions/card-balance.tsx
@@ -2,6 +2,7 @@ import Button from "@/components/common/button";
 import CardUI from "@/components/common/card-content";
 import RowLabelInfo from "@/components/common/row-label-info";
 import { numberWithCommas } from "@/lib/strings";
+import { useUserStore } from "@/lib/zustand/user";
 import { useWalletsStore } from "@/lib/zustand/wallets";
 import { Wallet } from "@/types/wallet";
 import Link from "next/link";
@@ -9,8 +10,13 @@ import { useEffect, useState } from "react";
 
 export default function CardBalance({ appWallet }: { appWallet: Wallet }) {
   const walletsUtxos = useWalletsStore((state) => state.walletsUtxos);
+  const userAssets = useUserStore((state) => state.userAssets);
+  const userAssetMetadata = useUserStore((state) => state.userAssetMetadata);
   const utxos = walletsUtxos[appWallet.id];
   const [balance, setBalance] = useState<number>(0);
+
+  console.log("userAssets", userAssets);
+  console.log("userAssetMetadata", userAssetMetadata);
 
   useEffect(() => {
     async function getBalance() {

--- a/src/components/pages/wallet/transactions/card-balance.tsx
+++ b/src/components/pages/wallet/transactions/card-balance.tsx
@@ -2,21 +2,15 @@ import Button from "@/components/common/button";
 import CardUI from "@/components/common/card-content";
 import RowLabelInfo from "@/components/common/row-label-info";
 import { numberWithCommas } from "@/lib/strings";
-import { useUserStore } from "@/lib/zustand/user";
 import { useWalletsStore } from "@/lib/zustand/wallets";
-import { Wallet } from "@/types/wallet";
+import type { Wallet } from "@/types/wallet";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
 export default function CardBalance({ appWallet }: { appWallet: Wallet }) {
   const walletsUtxos = useWalletsStore((state) => state.walletsUtxos);
-  const userAssets = useUserStore((state) => state.userAssets);
-  const userAssetMetadata = useUserStore((state) => state.userAssetMetadata);
   const utxos = walletsUtxos[appWallet.id];
   const [balance, setBalance] = useState<number>(0);
-
-  console.log("userAssets", userAssets);
-  console.log("userAssetMetadata", userAssetMetadata);
 
   useEffect(() => {
     async function getBalance() {

--- a/src/components/pages/wallet/transactions/transaction-card.tsx
+++ b/src/components/pages/wallet/transactions/transaction-card.tsx
@@ -270,12 +270,10 @@ export default function TransactionCard({
                         ? `$${assetMetadata?.ticker}`
                         : unit.unit;
                   return (
-                    <>
-                      <span key={unit.unit}>
-                        {j > 0 && " + "}
-                        {unit.quantity / Math.pow(10, decimals)} {assetName}
-                      </span>
-                    </>
+                    <span key={`${unit.unit}-${j}`}>
+                      {j > 0 && " + "}
+                      {unit.quantity / Math.pow(10, decimals)} {assetName}
+                    </span>
                   );
                 })}
               </div>

--- a/src/components/pages/wallet/transactions/transaction-card.tsx
+++ b/src/components/pages/wallet/transactions/transaction-card.tsx
@@ -294,7 +294,7 @@ export default function TransactionCard({
         })}
       </>
     );
-  }, [txJson, appWallet, walletAssetMetadata]);
+  }, [txJson, walletAssetMetadata]);
 
   if (!appWallet) return <></>;
   return (

--- a/src/lib/strings.ts
+++ b/src/lib/strings.ts
@@ -11,7 +11,7 @@ export function numberWithCommas(x: number) {
 }
 
 export function lovelaceToAda(lovelace: number | string) {
-  return `₳ ${(Math.floor((parseInt(String(lovelace)) / 1000000)*100))/100}`;
+  return `₳ ${Math.floor((parseInt(String(lovelace)) / 1000000) * 100) / 100}`;
 }
 
 export function dateToFormatted(date: Date) {

--- a/src/lib/zustand/user.ts
+++ b/src/lib/zustand/user.ts
@@ -1,3 +1,4 @@
+import { Asset } from "@meshsdk/core";
 import { User } from "@prisma/client";
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
@@ -5,6 +6,19 @@ import { persist, createJSONStorage } from "zustand/middleware";
 interface UserState {
   userAddress: string | undefined;
   setUserAddress: (address: string | undefined) => void;
+  userAssets: Asset[];
+  setUserAssets: (assets: Asset[]) => void;
+  userAssetMetadata: {
+    [policyId: string]: {
+      assetName: string;
+      decimals: number;
+    };
+  };
+  setUserAssetMetadata: (
+    policyId: string,
+    assetName: string,
+    decimals: number,
+  ) => void;
   user: User | undefined;
   setUser: (user: User | undefined) => void;
   pastWallet: string | undefined;
@@ -20,6 +34,16 @@ export const useUserStore = create<UserState>()(
       setUser: (user) => set({ user }),
       pastWallet: undefined,
       setPastWallet: (wallet) => set({ pastWallet: wallet }),
+      userAssets: [],
+      setUserAssets: (assets) => set({ userAssets: assets }),
+      userAssetMetadata: {},
+      setUserAssetMetadata: (policyId, assetName, decimals) =>
+        set((state) => ({
+          userAssetMetadata: {
+            ...state.userAssetMetadata,
+            [policyId]: { assetName, decimals },
+          },
+        })),
     }),
     {
       name: "persisted-state",

--- a/src/lib/zustand/wallets.ts
+++ b/src/lib/zustand/wallets.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { UTxO } from "@meshsdk/core";
+import { Asset, UTxO } from "@meshsdk/core";
 import { OnChainTransaction } from "@/types/transaction";
 import { BlockfrostDrepInfo } from "@/types/governance";
 
@@ -46,6 +46,19 @@ interface State {
   ) => void;
   walletLastUpdated: { [walletId: string]: number };
   setWalletLastUpdated: (walletId: string, timestamp: number) => void;
+  walletAssets: Asset[];
+  setWalletAssets: (assets: Asset[]) => void;
+  walletAssetMetadata: {
+    [policyId: string]: {
+      assetName: string;
+      decimals: number;
+    };
+  };
+  setWalletAssetMetadata: (
+    policyId: string,
+    assetName: string,
+    decimals: number,
+  ) => void;
   drepInfo: BlockfrostDrepInfo | undefined;
   setDrepInfo: (drepInfo: BlockfrostDrepInfo) => void;
   drepRegistered: boolean;
@@ -73,6 +86,16 @@ export const useWalletsStore = create<State>()(
             [walletId]: timestamp,
           },
         }),
+      walletAssets: [],
+      setWalletAssets: (assets) => set({ walletAssets: assets }),
+      walletAssetMetadata: {},
+      setWalletAssetMetadata: (policyId, assetName, decimals) =>
+        set((state) => ({
+          walletAssetMetadata: {
+            ...state.walletAssetMetadata,
+            [policyId]: { assetName, decimals },
+          },
+        })),
       drepInfo: undefined,
       setDrepInfo: (drepInfo) => set({ drepInfo }),
       drepRegistered: get()?.drepInfo?.active ?? false,

--- a/src/lib/zustand/wallets.ts
+++ b/src/lib/zustand/wallets.ts
@@ -52,12 +52,16 @@ interface State {
     [policyId: string]: {
       assetName: string;
       decimals: number;
+      image: string;
+      ticker: string;
     };
   };
   setWalletAssetMetadata: (
     policyId: string,
     assetName: string,
     decimals: number,
+    image: string,
+    ticker: string,
   ) => void;
   drepInfo: BlockfrostDrepInfo | undefined;
   setDrepInfo: (drepInfo: BlockfrostDrepInfo) => void;
@@ -89,11 +93,11 @@ export const useWalletsStore = create<State>()(
       walletAssets: [],
       setWalletAssets: (assets) => set({ walletAssets: assets }),
       walletAssetMetadata: {},
-      setWalletAssetMetadata: (policyId, assetName, decimals) =>
+      setWalletAssetMetadata: (policyId, assetName, decimals, image, ticker) =>
         set((state) => ({
           walletAssetMetadata: {
             ...state.walletAssetMetadata,
-            [policyId]: { assetName, decimals },
+            [policyId]: { assetName, decimals, image, ticker },
           },
         })),
       drepInfo: undefined,

--- a/src/pages/wallets/[wallet]/balance/index.tsx
+++ b/src/pages/wallets/[wallet]/balance/index.tsx
@@ -1,0 +1,5 @@
+import WalletBalance from "@/components/pages/wallet/balance";
+
+export default function Page() {
+  return <WalletBalance />;
+}


### PR DESCRIPTION
# Cardano Native Assets

## Summary
This PR adds support for native assets for depositing and withdrawing funds to the Multisig.

## Changes to local Zustand storage
In the `UserState`, I added `userAssets`, `setUserAssets`, `userAssetMetadata`, and `setUserAssetMetadata`. This stores information about the assets in a user's wallet in local storage so we don't have to keep fetching it throughout the app.

In `WalletState`, I added `walletAssets`, `setWalletAssets`, `walletAssetMetadata`, and `setWalletAssetMetadata`. This similarly stores information about the app that's selected.

## Depositing Native Assets
![image](https://github.com/user-attachments/assets/28137a54-8a94-4f1d-a2e8-658643eced8c)
Wallet assets will show up in a dropdown. Here are the assets held by this demo wallet.

![image](https://github.com/user-attachments/assets/1c8b1247-237b-48fc-b8ac-2dd6a514de2b)
The user can select an asset to deposit from their list of user wallet assets.

![image](https://github.com/user-attachments/assets/3b769ffe-0df0-47e3-a315-2006286d3060)

## Spending Native Assets
### Creating New Transactions to spend Native Assets
![image](https://github.com/user-attachments/assets/53044a49-69b7-4227-865e-3e0e295810b5)
Similarly to making a deposit, when creating a new transaction to spend out of the multisig, the user will now select an asset from the asset dropdown box which contains the app wallet assets.

### Manually Selecting UTxOs
![image](https://github.com/user-attachments/assets/e97bd136-9ac7-4452-8cf2-1cdd926edb3d)
Native asset information shows up in this table as well.

### Viewing Pending Transactions to spend Native Assets
![image](https://github.com/user-attachments/assets/2e794625-1cc8-4e9e-8950-13ae542e729c)
This is what it looks like, I also added a `to` address to each of these outputs, I think this is pretty important information.

## Viewing Native Asset Transactions 
![image](https://github.com/user-attachments/assets/06e00887-8746-49ce-bc6c-4d1fdb90bab5)
This is how native asset transactions show up in the transactions list.

## Balance Updates
### Balance Widget on Transactions Page
![image](https://github.com/user-attachments/assets/98fe2c9b-2ada-4a3b-8f0c-c5e5f6ea1cca)
Mainly about ADA, shows how many other assets the wallet holds.

### Balance Page
![image](https://github.com/user-attachments/assets/47e85ff7-2e75-44ca-a24e-d1b581ecbf6a)
I also added a new `Balance` page like we discussed. This has a similar balance widget to the transactions page, but includes a full expanded list of all native assets.
