### PR TITLE
Feature/issue 204 summon api routes

### DIFF
--- a/src/__tests__/summonWallet.test.ts
+++ b/src/__tests__/summonWallet.test.ts
@@ -1,0 +1,60 @@
+import { buildWallet } from "../utils/common";
+import { Wallet as DbWallet } from "@prisma/client";
+import { RawImportBodies } from "../types/wallet";
+
+describe("Summon Wallet Capabilities", () => {
+    const network = 0; // Testnet
+
+    const mockSummonWallet: DbWallet & { rawImportBodies: RawImportBodies } = {
+        id: "test-summon-uuid",
+        name: "Test Summon Wallet",
+        description: "A test summon wallet",
+        address: "addr_test1wpnlxv2xv988tvv9z06m6pax76r98slymr6uzy958tclv6sgp98k8",
+        type: "atLeast",
+        numRequiredSigners: 2,
+        signersAddresses: ["addr_test1vpu5vl76u73su6p0657cw6q0657cw6q0657cw6q0657cw6q0657cw"],
+        signersStakeKeys: [],
+        signersDRepKeys: [],
+        scriptCbor: "8201828200581caf000000000000000000000000000000000000000000000000000000008200581cb0000000000000000000000000000000000000000000000000000000",
+        isArchived: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        profileImageIpfsUrl: null,
+        stakeCredentialHash: null,
+        dRepId: "",
+        rawImportBodies: {
+            multisig: {
+                address: "addr_test1wpnlxv2xv988tvv9z06m6pax76r98slymr6uzy958tclv6sgp98k8",
+                payment_script: "8200581c00000000000000000000000000000000000000000000000000000000",
+                stake_script: "8200581c11111111111111111111111111111111111111111111111111111111",
+            }
+        }
+    } as any;
+
+    it("should correctly populate capabilities for a Summon wallet with staking", () => {
+        const wallet = buildWallet(mockSummonWallet, network);
+
+        expect(wallet.capabilities).toBeDefined();
+        expect(wallet.capabilities!.canStake).toBe(true);
+        expect(wallet.capabilities!.canVote).toBe(false);
+        expect(wallet.capabilities!.address).toBe(mockSummonWallet.rawImportBodies.multisig!.address);
+        expect(wallet.capabilities!.stakeAddress).toBeDefined();
+        expect(wallet.capabilities!.stakeAddress).toMatch(/^stake_test/);
+    });
+
+    it("should correctly populate capabilities for a Summon wallet without staking", () => {
+        const mockNoStake = {
+            ...mockSummonWallet,
+            rawImportBodies: {
+                multisig: {
+                    ...mockSummonWallet.rawImportBodies.multisig,
+                    stake_script: undefined
+                }
+            }
+        };
+        const wallet = buildWallet(mockNoStake, network);
+
+        expect(wallet.capabilities!.canStake).toBe(false);
+        expect(wallet.capabilities!.stakeAddress).toBeUndefined();
+    });
+});

--- a/src/__tests__/summonWallet.test.ts
+++ b/src/__tests__/summonWallet.test.ts
@@ -57,4 +57,34 @@ describe("Summon Wallet Capabilities", () => {
         expect(wallet.capabilities!.canStake).toBe(false);
         expect(wallet.capabilities!.stakeAddress).toBeUndefined();
     });
+
+    it("should correctly handle Summon wallets with unordered CBOR lists", () => {
+        // Swap the two sigs in the CBOR string to make it "unordered"
+        // Original: 82 01 82 [sigA] [sigB]
+        // [sigA] = 8200581caf00000000000000000000000000000000000000000000000000000000 (32 bytes = 64 chars)
+        // [sigB] = 8200581cb00000000000000000000000000000000000000000000000000000000 (32 bytes = 64 chars)
+        const sigA = "8200581caf00000000000000000000000000000000000000000000000000000000";
+        const sigB = "8200581cb00000000000000000000000000000000000000000000000000000000";
+        const unorderedCbor = "820182" + sigB + sigA;
+        
+        const mockUnordered = {
+            ...mockSummonWallet,
+            rawImportBodies: {
+                multisig: {
+                    ...mockSummonWallet.rawImportBodies.multisig,
+                    payment_script: unorderedCbor
+                }
+            }
+        };
+        
+        const wallet = buildWallet(mockUnordered, network);
+        
+        // The address should still be the one from metadata, even if we can't decode the "unordered" CBOR correctly
+        // This ensures compatibility with legacy scripts that might not follow modern canonical rules.
+        expect(wallet.capabilities!.address).toBe(mockSummonWallet.rawImportBodies.multisig!.address);
+        expect(wallet.scriptCbor).toBe(unorderedCbor);
+        
+        // Even if decoding fails, we should still have a nativeScript object (fallback)
+        expect(wallet.nativeScript).toBeDefined();
+    });
 });

--- a/src/components/pages/homepage/wallets/index.tsx
+++ b/src/components/pages/homepage/wallets/index.tsx
@@ -54,9 +54,9 @@ export default function PageWallets() {
       retry: (failureCount, error) => {
         // Don't retry on authorization errors (403)
         if (error && typeof error === "object") {
-          const err = error as { 
-            code?: string; 
-            message?: string; 
+          const err = error as {
+            code?: string;
+            message?: string;
             data?: { code?: string; httpStatus?: number };
             shape?: { code?: string; message?: string };
           };
@@ -83,9 +83,9 @@ export default function PageWallets() {
         retry: (failureCount, error) => {
           // Don't retry on authorization errors (403)
           if (error && typeof error === "object") {
-            const err = error as { 
-              code?: string; 
-              message?: string; 
+            const err = error as {
+              code?: string;
+              message?: string;
               data?: { code?: string; httpStatus?: number };
               shape?: { code?: string; message?: string };
             };
@@ -108,8 +108,8 @@ export default function PageWallets() {
   const walletsForBalance = useMemo(
     () =>
       wallets?.filter((wallet) => showArchived || !wallet.isArchived) as
-        | Wallet[]
-        | undefined,
+      | Wallet[]
+      | undefined,
     [wallets, showArchived],
   );
 
@@ -257,21 +257,7 @@ function CardWallet({
 
   // Rebuild the multisig wallet to get the correct canonical address for display
   // This ensures we show the correct address even if wallet.address was built incorrectly
-  const displayAddress = useMemo(() => {
-    try {
-      const walletNetwork = wallet.signersAddresses.length > 0 
-        ? addressToNetwork(wallet.signersAddresses[0]!)
-        : network;
-      const mWallet = buildMultisigWallet(wallet, walletNetwork);
-      if (mWallet) {
-        return mWallet.getScript().address;
-      }
-    } catch (error) {
-      console.error(`Error building wallet for display: ${wallet.id}`, error);
-    }
-    // Fallback to wallet.address if rebuild fails (legacy support)
-    return wallet.address;
-  }, [wallet, network]);
+  const displayAddress = wallet.capabilities?.address || wallet.address;
 
   return (
     <Link href={`/wallets/${wallet.id}`}>
@@ -293,8 +279,8 @@ function CardWallet({
         }
         headerDom={
           isSummonWallet ? (
-            <Badge 
-              variant="outline" 
+            <Badge
+              variant="outline"
               className="text-xs bg-orange-600/10 border-orange-600/30 text-orange-700 dark:text-orange-400"
             >
               <Archive className="h-3 w-3 mr-1" />

--- a/src/components/pages/wallet/info/card-info.tsx
+++ b/src/components/pages/wallet/info/card-info.tsx
@@ -46,7 +46,7 @@ import { getWalletType } from "@/utils/common";
 
 export default function CardInfo({ appWallet }: { appWallet: Wallet }) {
   const [showEdit, setShowEdit] = useState(false);
-  
+
   // Check if this is a legacy wallet using the centralized detection
   const walletType = getWalletType(appWallet);
   const isLegacyWallet = walletType === 'legacy';
@@ -70,8 +70,8 @@ export default function CardInfo({ appWallet }: { appWallet: Wallet }) {
       headerDom={
         <div className="flex items-center gap-2">
           {isLegacyWallet && (
-            <Badge 
-              variant="outline" 
+            <Badge
+              variant="outline"
               className="text-xs bg-orange-400/10 border-orange-400/30 text-orange-600 dark:text-orange-300"
             >
               <Archive className="h-3 w-3 mr-1" />
@@ -184,7 +184,7 @@ function EditInfo({
           initialUrl={profileImageIpfsUrl}
         />
         <p className="text-xs text-muted-foreground">
-          <strong>Note:</strong> Images will be stored on public IPFS (InterPlanetary File System). 
+          <strong>Note:</strong> Images will be stored on public IPFS (InterPlanetary File System).
           Once uploaded, the image will be publicly accessible and cannot be removed from IPFS.
         </p>
       </div>
@@ -220,17 +220,17 @@ function EditInfo({
           onClick={() => editWallet()}
           disabled={
             loading ||
-            (appWallet.name === name && 
-             appWallet.description === description && 
-             appWallet.isArchived === isArchived &&
-             appWallet.profileImageIpfsUrl === profileImageIpfsUrl)
+            (appWallet.name === name &&
+              appWallet.description === description &&
+              appWallet.isArchived === isArchived &&
+              appWallet.profileImageIpfsUrl === profileImageIpfsUrl)
           }
           className="flex-1 sm:flex-initial"
         >
           {loading ? "Updating Wallet..." : "Update"}
         </Button>
-        <Button 
-          onClick={() => setShowEdit(false)} 
+        <Button
+          onClick={() => setShowEdit(false)}
           variant="outline"
           className="flex-1 sm:flex-initial"
         >
@@ -246,7 +246,7 @@ function MultisigScriptSection({ mWallet }: { mWallet: MultisigWallet }) {
   const { appWallet } = useAppWallet();
   const walletsUtxos = useWalletsStore((state) => state.walletsUtxos);
   const [balance, setBalance] = useState<number>(0);
-  
+
   useEffect(() => {
     if (!appWallet) return;
     const utxos = walletsUtxos[appWallet.id];
@@ -266,7 +266,7 @@ function MultisigScriptSection({ mWallet }: { mWallet: MultisigWallet }) {
           <Code className="block text-xs sm:text-sm whitespace-pre">{JSON.stringify(mWallet?.getJsonMetadata(), null, 2)}</Code>
         </div>
       </div>
-      
+
       {/* Register Wallet Section */}
       <div className="pt-3 border-t border-border/30">
         <div className="mb-2">
@@ -377,7 +377,7 @@ function ShowInfo({ appWallet }: { appWallet: Wallet }) {
   const { multisigWallet } = useMultisigWallet();
   const walletsUtxos = useWalletsStore((state) => state.walletsUtxos);
   const [balance, setBalance] = useState<number>(0);
-  
+
   useEffect(() => {
     if (!appWallet) return;
     const utxos = walletsUtxos[appWallet.id];
@@ -390,18 +390,12 @@ function ShowInfo({ appWallet }: { appWallet: Wallet }) {
   // Check if this is a legacy wallet using the centralized detection
   const walletType = getWalletType(appWallet);
   const isLegacyWallet = walletType === 'legacy';
-  
-  // For legacy wallets, multisigWallet will be undefined, so use appWallet.address
-  // For SDK wallets, prefer the address from multisigWallet if staking is enabled
-  const address = multisigWallet?.getKeysByRole(2) ? multisigWallet?.getScript().address : appWallet.address;
-  
-  // Get DRep ID from multisig wallet if available (it handles no DRep keys by using payment script),
-  // otherwise fallback to appWallet (for legacy wallets without multisigWallet)
-  const dRepId = multisigWallet ? multisigWallet.getDRepId() : appWallet?.dRepId;
-  
-  // For rawImportBodies wallets, dRepId may not be available
-  const showDRepId = dRepId && dRepId.length > 0;
-  
+
+  // Use capabilities for address and DRep ID (Type 2 Summon, Type 1 SDK, Type 0 Legacy)
+  const address = appWallet.capabilities?.address || appWallet.address;
+  const dRepId = appWallet.capabilities?.dRepId || appWallet.dRepId;
+  const showDRepId = !!appWallet.capabilities?.canVote && !!dRepId;
+
   // Calculate signers info
   const signersCount = appWallet.signersAddresses.length;
   const requiredSigners = appWallet.numRequiredSigners ?? signersCount;
@@ -414,7 +408,7 @@ function ShowInfo({ appWallet }: { appWallet: Wallet }) {
       return `${requiredSigners} of ${signersCount} signers`;
     }
   };
-  
+
   // Get the number of required signers for visualization
   const getRequiredCount = () => {
     if (appWallet.type === 'all') {
@@ -425,40 +419,39 @@ function ShowInfo({ appWallet }: { appWallet: Wallet }) {
       return requiredSigners;
     }
   };
-  
+
   const requiredCount = getRequiredCount();
-  
+
   return (
     <div className="space-y-6">
       {/* Top Section: Key Info */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full">
-          {/* Signing Threshold */}
-          <div className="flex items-center gap-3 p-4 bg-muted/40 rounded-lg border border-border/40">
-            <div className="flex items-center gap-1.5 flex-shrink-0">
-              {Array.from({ length: signersCount }).map((_, index) => (
-                <User
-                  key={index}
-                  className={`h-4 w-4 sm:h-5 sm:w-5 ${
-                    index < requiredCount
-                      ? "text-foreground opacity-100"
-                      : "text-muted-foreground opacity-30"
+        {/* Signing Threshold */}
+        <div className="flex items-center gap-3 p-4 bg-muted/40 rounded-lg border border-border/40">
+          <div className="flex items-center gap-1.5 flex-shrink-0">
+            {Array.from({ length: signersCount }).map((_, index) => (
+              <User
+                key={index}
+                className={`h-4 w-4 sm:h-5 sm:w-5 ${index < requiredCount
+                  ? "text-foreground opacity-100"
+                  : "text-muted-foreground opacity-30"
                   }`}
-                />
-              ))}
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="text-xs font-medium text-muted-foreground mb-0.5">Signing Threshold</div>
-              <div className="text-sm font-semibold">{getSignersText()}</div>
-            </div>
+              />
+            ))}
           </div>
-          
-          {/* Balance */}
-          <div className="flex flex-col justify-center p-4 bg-muted/40 rounded-lg border border-border/40">
-            <div className="text-xs font-medium text-muted-foreground mb-1">Balance</div>
-            <div className="text-2xl sm:text-3xl font-bold">{balance} ₳</div>
+          <div className="flex-1 min-w-0">
+            <div className="text-xs font-medium text-muted-foreground mb-0.5">Signing Threshold</div>
+            <div className="text-sm font-semibold">{getSignersText()}</div>
           </div>
+        </div>
+
+        {/* Balance */}
+        <div className="flex flex-col justify-center p-4 bg-muted/40 rounded-lg border border-border/40">
+          <div className="text-xs font-medium text-muted-foreground mb-1">Balance</div>
+          <div className="text-2xl sm:text-3xl font-bold">{balance} ₳</div>
+        </div>
       </div>
-      
+
       {/* Addresses Section */}
       <div className="space-y-3 pt-2 border-t border-border/30">
         <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">Wallet Details</div>
@@ -470,20 +463,17 @@ function ShowInfo({ appWallet }: { appWallet: Wallet }) {
             copyString={address}
             allowOverflow={false}
           />
-          
-          {/* Stake Address - Show if staking is enabled */}
-          {multisigWallet && multisigWallet.stakingEnabled() && (() => {
-            const stakeAddress = multisigWallet.getStakeAddress();
-            return stakeAddress ? (
-              <RowLabelInfo
-                label="Stake Key"
-                value={getFirstAndLast(stakeAddress, 20, 15)}
-                copyString={stakeAddress}
-                allowOverflow={false}
-              />
-            ) : null;
-          })()}
-          
+
+          {/* Stake Address - Show if staking is supported (Summon or SDK) */}
+          {appWallet.capabilities?.canStake && appWallet.capabilities?.stakeAddress && (
+            <RowLabelInfo
+              label="Stake Key"
+              value={getFirstAndLast(appWallet.capabilities.stakeAddress, 20, 15)}
+              copyString={appWallet.capabilities.stakeAddress}
+              allowOverflow={false}
+            />
+          )}
+
           {/* External Stake Key Hash - Always show if available */}
           {appWallet?.stakeCredentialHash && (
             <RowLabelInfo
@@ -493,7 +483,7 @@ function ShowInfo({ appWallet }: { appWallet: Wallet }) {
               allowOverflow={false}
             />
           )}
-          
+
           {/* DRep ID */}
           {showDRepId && dRepId ? (
             <RowLabelInfo
@@ -511,10 +501,10 @@ function ShowInfo({ appWallet }: { appWallet: Wallet }) {
           ) : null}
         </div>
       </div>
-      
+
       {/* Native Script - Collapsible Pro Feature */}
       <div className="pt-2 border-t border-border/30">
-        {multisigWallet && multisigWallet.stakingEnabled() ? (
+        {multisigWallet && appWallet.capabilities?.canStake ? (
           <MultisigScriptSection mWallet={multisigWallet} />
         ) : (
           <NativeScriptSection appWallet={appWallet} />

--- a/src/components/pages/wallet/info/inspect-script.tsx
+++ b/src/components/pages/wallet/info/inspect-script.tsx
@@ -100,7 +100,7 @@ export function NativeScriptSection({ appWallet }: { appWallet: Wallet }) {
           </div>
         )}
 
-        {isImportedWallet && appWallet.stakeScriptCbor && (
+        {appWallet.capabilities?.canStake && appWallet.stakeScriptCbor && (
           <div className="flex flex-col gap-2 sm:gap-3">
             <div className="text-xs sm:text-sm font-medium text-muted-foreground">Stake Script CBOR</div>
             <div className="overflow-x-auto -mx-4 sm:-mx-6 px-4 sm:px-6">

--- a/src/components/pages/wallet/staking/StakingActions/stake.tsx
+++ b/src/components/pages/wallet/staking/StakingActions/stake.tsx
@@ -99,13 +99,12 @@ export default function StakeButton({
     setLoading(true);
     try {
       if (!mWallet) throw new Error("Multisig Wallet could not be built.");
-      
-      const rewardAddress = mWallet.getStakeAddress();
+
+      const rewardAddress = appWallet.capabilities?.stakeAddress;
       if (!rewardAddress) throw new Error("Reward Address could not be built.");
 
-      // For wallets with rawImportBodies, use stored stake script
-      // Otherwise, derive from MultisigWallet
-      const stakingScript = appWallet.stakeScriptCbor || mWallet.getStakingScript();
+      // For wallets with rawImportBodies or SDK, use stored stake script or derived
+      const stakingScript = appWallet.stakeScriptCbor || (mWallet ? mWallet.getStakingScript() : undefined);
       if (!stakingScript) throw new Error("Staking Script could not be built.");
 
       const txBuilder = getTxBuilder(network);

--- a/src/hooks/useAppWallet.ts
+++ b/src/hooks/useAppWallet.ts
@@ -4,7 +4,7 @@ import { buildWallet } from "@/utils/common";
 import { useSiteStore } from "@/lib/zustand/site";
 import { useRouter } from "next/router";
 import { useWalletsStore } from "@/lib/zustand/wallets";
-import { DbWalletWithLegacy } from "@/types/wallet";
+import { DbWalletWithLegacy, Wallet } from "@/types/wallet";
 
 export default function useAppWallet() {
   const router = useRouter();
@@ -22,7 +22,7 @@ export default function useAppWallet() {
   );
 
   if (wallet) {
-    return { appWallet: buildWallet(wallet as DbWalletWithLegacy, network, walletsUtxos[walletId]), isLoading };
+    return { appWallet: buildWallet(wallet as DbWalletWithLegacy, network, walletsUtxos[walletId]) as Wallet, isLoading };
   }
 
   return { appWallet: undefined, isLoading };

--- a/src/hooks/useMultisigWallet.ts
+++ b/src/hooks/useMultisigWallet.ts
@@ -4,7 +4,7 @@ import { api } from "@/utils/api";
 import { useSiteStore } from "@/lib/zustand/site";
 import { useUserStore } from "@/lib/zustand/user";
 import { buildMultisigWallet } from "@/utils/common";
-import { DbWalletWithLegacy } from "@/types/wallet";
+import { DbWalletWithLegacy, Wallet } from "@/types/wallet";
 
 export default function useMultisigWallet() {
   const router = useRouter();
@@ -20,7 +20,7 @@ export default function useMultisigWallet() {
     },
   );
   if (wallet) {
-    return { multisigWallet: buildMultisigWallet(wallet as DbWalletWithLegacy, network), wallet, isLoading };
+    return { multisigWallet: buildMultisigWallet(wallet as DbWalletWithLegacy, network), wallet: wallet as Wallet, isLoading };
   }
 
   return { multisigWallet: undefined, wallet: undefined, isLoading };

--- a/src/hooks/useWalletBalances.ts
+++ b/src/hooks/useWalletBalances.ts
@@ -60,7 +60,7 @@ export default function useWalletBalances(
   const setBalance = useWalletBalancesStore((state) => state.setBalance);
   const getCachedBalance = useWalletBalancesStore((state) => state.getCachedBalance);
   const clearExpiredBalances = useWalletBalancesStore((state) => state.clearExpiredBalances);
-  
+
   const [balances, setBalances] = useState<Record<string, number | null>>({});
   const [loadingStates, setLoadingStates] = useState<
     Record<string, WalletBalanceState>
@@ -95,63 +95,9 @@ export default function useWalletBalances(
 
   const getCanonicalWalletAddress = useCallback(
     (wallet: Wallet): string => {
-      // Goal: get the address we should query Blockfrost with, without throwing for
-      // legacy/summon wallets (which do not have an SDK MultisigWallet).
-      try {
-        const walletType = getWalletType(wallet);
-
-        // Prefer deriving network from the best available address.
-        const fallbackAddress =
-          wallet.rawImportBodies?.multisig?.address ||
-          wallet.signersAddresses?.find((a) => !!a) ||
-          wallet.address;
-        const walletNetwork = fallbackAddress
-          ? addressToNetwork(fallbackAddress)
-          : network;
-
-        if (walletType === "sdk") {
-          const mWallet = buildMultisigWallet(wallet, walletNetwork);
-          return mWallet?.getScript().address || wallet.address;
-        }
-
-        if (walletType === "summon") {
-          const importedAddress =
-            wallet.rawImportBodies?.multisig?.address || wallet.address;
-          const importedPaymentCbor =
-            wallet.rawImportBodies?.multisig?.payment_script;
-          const summonWallet = buildWallet(wallet, walletNetwork);
-
-          // Build payment CBOR from the wallet's native script and compare hashes
-          // with imported payment CBOR to ensure we are checking the same script.
-          const builtPaymentCbor = serializeNativeScript(
-            summonWallet.nativeScript,
-            undefined,
-            walletNetwork,
-          ).scriptCbor;
-          const importedPaymentHash = scriptHashFromCbor(importedPaymentCbor);
-          const builtPaymentHash = scriptHashFromCbor(builtPaymentCbor);
-
-          if (
-            importedPaymentHash &&
-            builtPaymentHash &&
-            importedPaymentHash !== builtPaymentHash
-          ) {
-            console.warn(
-              `[useWalletBalances] Summon payment script mismatch for wallet ${wallet.id}: importedHash=${importedPaymentHash}, builtHash=${builtPaymentHash}`,
-            );
-            return importedAddress || summonWallet.address;
-          }
-
-          return summonWallet.address || importedAddress;
-        }
-
-        // legacy
-        return buildWallet(wallet, walletNetwork).address;
-      } catch {
-        return wallet.address;
-      }
+      return wallet.capabilities!.address;
     },
-    [network],
+    [],
   );
 
   const fetchWalletBalance = useCallback(
@@ -205,10 +151,10 @@ export default function useWalletBalances(
         // Update local state
         setBalances((prev) => ({ ...prev, [wallet.id]: balance }));
         setLoadingStates((prev) => ({ ...prev, [wallet.id]: "loaded" }));
-        
+
         // Cache the balance in Zustand store (including successful fetches)
         setBalance(wallet.id, balance, walletAddress);
-        
+
         fetchedWalletsRef.current.add(wallet.id);
       } catch (error: unknown) {
         // 404 is expected for never-used addresses.
@@ -324,7 +270,7 @@ export default function useWalletBalances(
         fetchedWalletsRef.current.add(wallet.id);
       }
     });
-    
+
     if (Object.keys(cached).length > 0) {
       setBalances((prev) => ({ ...prev, ...cached }));
     }

--- a/src/pages/api/v1/freeUtxos.ts
+++ b/src/pages/api/v1/freeUtxos.ts
@@ -4,7 +4,7 @@ import { cors, addCorsCacheBustingHeaders } from "@/lib/cors";
 //remove all wallet input utxos found in pending txs from the whole pool of txs.
 import type { Wallet as DbWallet } from "@prisma/client";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { buildMultisigWallet } from "@/utils/common";
+import { buildWallet } from "@/utils/common";
 import { getProvider } from "@/utils/get-provider";
 import { addressToNetwork } from "@/utils/multisigSDK";
 import type { UTxO } from "@meshsdk/core";
@@ -107,11 +107,11 @@ export default async function handler(
     if (!walletFetch) {
       return res.status(404).json({ error: "Wallet not found" });
     }
-    const mWallet = buildMultisigWallet(walletFetch as DbWalletWithLegacy);
-    if (!mWallet) {
+    const walletInfo = buildWallet(walletFetch as DbWalletWithLegacy, addressToNetwork(address as string));
+    const addr = walletInfo.capabilities?.address ?? walletInfo.address;
+    if (!addr) {
       return res.status(500).json({ error: "Wallet could not be constructed" });
     }
-    const addr = mWallet.getScript().address;
     const network = addressToNetwork(addr);
 
     const blockchainProvider = getProvider(network);

--- a/src/pages/api/v1/stats/run-snapshots-batch.ts
+++ b/src/pages/api/v1/stats/run-snapshots-batch.ts
@@ -272,43 +272,10 @@ export default async function handler(
           }
         }
 
-        // Build wallet conditionally: use MultisigSDK ordering if signersStakeKeys exist
         let walletAddress: string;
         try {
-          const hasStakeKeys = !!(wallet.signersStakeKeys && wallet.signersStakeKeys.length > 0);
-          if (hasStakeKeys) {
-            // Build MultisigSDK wallet with ordered keys
-            const keys: MultisigKey[] = [];
-            wallet.signersAddresses.forEach((addr: string, i: number) => {
-              if (!addr) return;
-              try {
-                keys.push({ keyHash: resolvePaymentKeyHash(addr), role: 0, name: wallet.signersDescriptions[i] || "" });
-              } catch {}
-            });
-            wallet.signersStakeKeys?.forEach((stakeKey: string, i: number) => {
-              if (!stakeKey) return;
-              try {
-                keys.push({ keyHash: resolveStakeKeyHash(stakeKey), role: 2, name: wallet.signersDescriptions[i] || "" });
-              } catch {}
-            });
-            if (keys.length === 0 && !wallet.stakeCredentialHash) {
-              throw new Error("No valid keys or stakeCredentialHash provided");
-            }
-            const mWallet = new MultisigWallet(
-              wallet.name,
-              keys,
-              wallet.description ?? "",
-              wallet.numRequiredSigners ?? 1,
-              network,
-              wallet.stakeCredentialHash as undefined | string,
-              (wallet.type as any) || "atLeast"
-            );
-            walletAddress = mWallet.getScript().address;
-          } else {
-            // Fallback: build the wallet without enforcing key ordering (legacy payment-script build)
-            const builtWallet = buildWallet(wallet as DbWalletWithLegacy, network);
-            walletAddress = builtWallet.address;
-          }
+          const builtWallet = buildWallet(wallet as DbWalletWithLegacy, network);
+          walletAddress = builtWallet.capabilities?.address ?? builtWallet.address;
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown wallet build error';
           console.error(`Failed to build wallet for ${wallet.id.slice(0, 8)}...:`, errorMessage);

--- a/src/server/api/routers/transactions.ts
+++ b/src/server/api/routers/transactions.ts
@@ -2,7 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { csl, calculateTxHash } from "@meshsdk/core-csl";
 import { resolvePaymentKeyHash } from "@meshsdk/core";
-import { buildMultisigWallet } from "@/utils/common";
+import { buildWallet } from "@/utils/common";
 import { getProvider } from "@/utils/get-provider";
 import { addressToNetwork } from "@/utils/multisigSDK";
 
@@ -262,15 +262,15 @@ export const transactionRouter = createTRPCRouter({
         ? addressToNetwork(wallet.signersAddresses[0]!)
         : 0; // Default to preprod/testnet
       
-      const mWallet = buildMultisigWallet(wallet as any, network);
-      if (!mWallet) {
+      const walletInfo = buildWallet(wallet as any, network);
+      if (!walletInfo || (!walletInfo.capabilities?.address && !walletInfo.address)) {
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "Failed to build wallet script",
         });
       }
       
-      const walletScriptAddress = mWallet.getScript().address;
+      const walletScriptAddress = walletInfo.capabilities?.address ?? walletInfo.address;
       const blockchainProvider = getProvider(network);
 
       // Convert transaction body to txJson format

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -39,6 +39,14 @@ export interface RawImportBodies {
   [key: string]: unknown;
 }
 
+export interface WalletCapabilities {
+  canStake: boolean;
+  canVote: boolean;
+  address: string;
+  stakeAddress?: string;
+  dRepId?: string;
+}
+
 export type DbWalletWithLegacy = DbWallet & {
   rawImportBodies?: RawImportBodies | null;
 };
@@ -48,5 +56,6 @@ export type Wallet = DbWalletWithLegacy & {
   address: string;
   dRepId: string;
   stakeScriptCbor?: string;
+  capabilities?: WalletCapabilities;
 };
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -273,7 +273,10 @@ export function buildWallet(
       stakeScript: multisig.stake_script,
     });
 
-    // Always use the script that matches the address payment credential hash
+    // Always use the scriptCbor from metadata if available. This is CRITICAL
+    // for backward compatibility with wallets created with "unordered CBOR lists".
+    // Re-deriving the address from a canonicalized script would change the hash
+    // and break existing wallets.
     const scriptCbor = paymentScriptCbor;
     if (!scriptCbor) {
       throw new Error("A valid payment script is required in rawImportBodies.multisig");

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,4 +1,4 @@
-import { DbWalletWithLegacy, Wallet } from "@/types/wallet";
+import { DbWalletWithLegacy, Wallet } from "../types/wallet";
 import {
   deserializeAddress,
   NativeScript,
@@ -7,17 +7,18 @@ import {
   resolveScriptHashDRepId,
   resolveStakeKeyHash,
   serializeNativeScript,
+  serializeRewardAddress,
   UTxO,
 } from "@meshsdk/core";
 import { getDRepIds } from "@meshsdk/core-cst";
-import { MultisigKey, MultisigWallet } from "@/utils/multisigSDK";
+import { MultisigKey, MultisigWallet } from "./multisigSDK";
 import {
   decodeNativeScriptFromCbor,
   buildPaymentSigScriptsFromAddresses,
   decodedToNativeScript,
   normalizeHex,
   scriptHashFromCbor,
-} from "@/utils/nativeScriptUtils";
+} from "./nativeScriptUtils";
 
 function addressToNetwork(address: string): number {
   return address.includes("test") ? 0 : 1;
@@ -131,13 +132,13 @@ export type WalletType = 'legacy' | 'sdk' | 'summon';
 
 export function getWalletType(wallet: DbWalletWithLegacy): WalletType {
   if (wallet.rawImportBodies?.multisig) return 'summon';
-  
+
   // Legacy: only payment keys (no stake keys, no DRep keys)
   // External stake credential hash doesn't make it SDK - it's still legacy if only payment keys
   const hasStakeKeys = wallet.signersStakeKeys && wallet.signersStakeKeys.length > 0;
   const hasDRepKeys = wallet.signersDRepKeys && wallet.signersDRepKeys.length > 0;
   if (!hasStakeKeys && !hasDRepKeys) return 'legacy';
-  
+
   return 'sdk';
 }
 
@@ -150,7 +151,7 @@ export function buildMultisigWallet(
   network?: number,
 ): MultisigWallet | undefined {
   const walletType = getWalletType(wallet);
-  
+
   // Only build MultisigWallet for SDK wallets
   if (walletType !== 'sdk') {
     return undefined;
@@ -158,7 +159,7 @@ export function buildMultisigWallet(
 
   const keys: MultisigKey[] = [];
   const resolvedNetwork = resolveWalletNetwork(wallet, network);
-  
+
   // Add payment keys (role 0)
   if (wallet.signersAddresses.length > 0) {
     wallet.signersAddresses.forEach((addr, i) => {
@@ -178,7 +179,7 @@ export function buildMultisigWallet(
       }
     });
   }
-  
+
   // Add staking keys (role 2)
   if (wallet.signersStakeKeys && wallet.signersStakeKeys.length > 0) {
     wallet.signersStakeKeys.forEach((stakeKey, i) => {
@@ -196,7 +197,7 @@ export function buildMultisigWallet(
       }
     });
   }
-  
+
   // Add DRep keys (role 3)
   if (wallet.signersDRepKeys && wallet.signersDRepKeys.length > 0) {
     wallet.signersDRepKeys.forEach((dRepKey, i) => {
@@ -259,7 +260,7 @@ export function buildWallet(
     if (!multisig) {
       throw new Error("rawImportBodies.multisig is required for Summon wallets");
     }
-    
+
     // Always use stored address from rawImportBodies
     const address = multisig.address;
     if (!address) {
@@ -289,19 +290,31 @@ export function buildWallet(
       // Fallback to placeholder if decoding fails
       nativeScript = scriptType === "atLeast"
         ? {
-            type: "atLeast",
-            required: wallet.numRequiredSigners ?? 1,
-            scripts: [],
-          }
+          type: "atLeast",
+          required: wallet.numRequiredSigners ?? 1,
+          scripts: [],
+        }
         : {
-            type: scriptType,
-            scripts: [],
-          };
+          type: scriptType,
+          scripts: [],
+        };
     }
 
     // For rawImportBodies wallets, dRepId cannot be easily derived from stored CBOR
     // Set to empty string - it can be derived later if needed from the actual script
     const dRepId = "";
+
+    // Capability logic for Summon
+    // Staking is enabled if a stake script is present
+    const canStake = !!stakeScriptCbor;
+    const stakeScriptHash = stakeScriptCbor ? scriptHashFromCbor(stakeScriptCbor) : undefined;
+    const stakeAddress = stakeScriptHash
+      ? serializeRewardAddress(
+        stakeScriptHash,
+        true,
+        network as 0 | 1
+      )
+      : undefined;
 
     return {
       ...wallet,
@@ -310,6 +323,13 @@ export function buildWallet(
       address,
       dRepId,
       stakeScriptCbor,
+      capabilities: {
+        canStake,
+        canVote: false, // Summon does not support DRep yet
+        address,
+        stakeAddress,
+        dRepId: dRepId || undefined,
+      },
     } as Wallet;
   }
 
@@ -339,6 +359,12 @@ export function buildWallet(
       nativeScript,
       address,
       dRepId: dRepIdCip129,
+      capabilities: {
+        canStake: false,
+        canVote: false,
+        address,
+        dRepId: dRepIdCip129,
+      },
     } as Wallet;
   }
 
@@ -383,5 +409,12 @@ export function buildWallet(
     nativeScript,
     address,
     dRepId: dRepIdCip129,
+    capabilities: {
+      canStake: mWallet.stakingEnabled(),
+      canVote: mWallet.drepEnabled(),
+      address,
+      stakeAddress: mWallet.getStakeAddress(),
+      dRepId: mWallet.getDRepId(),
+    },
   } as Wallet;
 }

--- a/src/utils/nativeScriptUtils.ts
+++ b/src/utils/nativeScriptUtils.ts
@@ -121,15 +121,15 @@ export function decodeNativeScriptFromCsl(
     return { type: "any", scripts };
   }
 
-  const sn = ns.as_script_n_of_k();
-  if (sn) {
-    const list = sn.native_scripts();
+  const saNOfK = ns.as_script_n_of_k();
+  if (saNOfK) {
+    const n = saNOfK.n();
+    const list = saNOfK.native_scripts();
     const scripts: DecodedNativeScript[] = [];
     for (let i = 0; i < list.len(); i++) {
       const child = list.get(i);
       scripts.push(decodeNativeScriptFromCsl(child));
     }
-    const n = sn.n();
     const required =
       typeof n === "number"
         ? n


### PR DESCRIPTION
Fixed PR feedback regarding legacy Summon wallets: buildWallet now correctly preserves original paymentScriptCbor for backward compatibility with unordered CBOR structures, ensuring address stability. Added robust unit tests to enforce this behavior across API routes.