### PR TITLE
Fix missing User table on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev": "next dev",
     "postinstall": "prisma generate",
     "lint": "next lint",
+    "prestart": "prisma migrate deploy",
     "start": "next start",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/pages/api/v1/getNonce.ts
+++ b/src/pages/api/v1/getNonce.ts
@@ -30,14 +30,18 @@ export default async function handler(
 
       // Log whether the address has a corresponding user, but don't block nonce issuance.
       // This allows first-time wallet connections to authorize via nonce signing.
-      const user = await db.user.findUnique({ where: { address } });
-      if (!user) {
-        console.warn("[getNonce] Address has no User record yet:", address);
-      } else {
-        console.debug("[getNonce] Found User for address:", {
-          address,
-          userId: user.id,
-        });
+      try {
+        const user = await db.user.findUnique({ where: { address } });
+        if (!user) {
+          console.warn("[getNonce] Address has no User record yet:", address);
+        } else {
+          console.debug("[getNonce] Found User for address:", {
+            address,
+            userId: user.id,
+          });
+        }
+      } catch (userLookupError) {
+        console.warn("[getNonce] User lookup failed (table may not exist yet):", (userLookupError as Error).message);
       }
 
       // Check if a nonce already exists for this address in the database


### PR DESCRIPTION
## Summary
- Add `prestart` script to run `prisma migrate deploy` before `next start`, ensuring all database tables exist before the app accepts requests
- Wrap informational User lookup in `getNonce` with try/catch so nonce generation doesn't crash if the User table is temporarily unavailable

## Test plan
- [ ] Verify `npm start` runs migrations automatically before starting the server
- [ ] Verify `/api/v1/getNonce` works correctly when User table exists
- [ ] Verify `/api/v1/getNonce` degrades gracefully (logs warning, still issues nonce) if User table is missing

https://claude.ai/code/session_01Y4mDygMY7HNHAJz7GUs5dz