### PR TITLE
refactor: remove DREP and STAKE deposit constants from codebase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,89 +163,6 @@
         "openapi-types": ">=7"
       }
     },
-    "node_modules/@auth/core": {
-      "version": "0.34.3",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.34.3.tgz",
-      "integrity": "sha512-jMjY/S0doZnWYNV90x0jmU3B+UcrsfGYnukxYrRbj0CVvGI/MX3JbHsxSrx2d4mbnXaUsqJmAcDfoQWA6r0lOw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@panva/hkdf": "^1.1.1",
-        "@types/cookie": "0.6.0",
-        "cookie": "0.6.0",
-        "jose": "^5.1.3",
-        "oauth4webapi": "^2.10.4",
-        "preact": "10.11.3",
-        "preact-render-to-string": "5.2.3"
-      },
-      "peerDependencies": {
-        "@simplewebauthn/browser": "^9.0.1",
-        "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^7"
-      },
-      "peerDependenciesMeta": {
-        "@simplewebauthn/browser": {
-          "optional": true
-        },
-        "@simplewebauthn/server": {
-          "optional": true
-        },
-        "nodemailer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@auth/core/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@auth/core/node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/@auth/core/node_modules/preact": {
-      "version": "10.11.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
-      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/@auth/core/node_modules/preact-render-to-string": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
-      "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "pretty-format": "^3.8.0"
-      },
-      "peerDependencies": {
-        "preact": ">=10"
-      }
-    },
-    "node_modules/@auth/core/node_modules/pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@auth/prisma-adapter": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.1.tgz",
@@ -5343,24 +5260,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@simplewebauthn/browser": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-9.0.1.tgz",
-      "integrity": "sha512-wD2WpbkaEP4170s13/HUxPcAV5y4ZXaKo1TfNklS5zDefPinIgXOpgz1kpEvobAsaLPa2KeH7AKKX/od1mrBJw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@simplewebauthn/types": "^9.0.1"
-      }
-    },
-    "node_modules/@simplewebauthn/types": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-9.0.1.tgz",
-      "integrity": "sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
@@ -6356,13 +6255,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/cors": {
       "version": "2.8.19",
@@ -8395,7 +8287,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/bare-addon-resolve": {
       "version": "1.10.0",
@@ -9257,6 +9150,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9622,6 +9516,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -9763,6 +9658,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9914,7 +9810,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/confbox": {
       "version": "0.2.4",
@@ -12554,7 +12451,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphql": {
       "version": "16.13.2",
@@ -12637,6 +12535,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -13029,6 +12928,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -14462,7 +14362,8 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -16046,6 +15947,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -19652,16 +19554,6 @@
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
     },
-    "node_modules/oauth4webapi": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
-      "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -22672,6 +22564,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -24253,20 +24146,6 @@
         "node": ">=12.20.0"
       }
     },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/utf8-codec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
@@ -24833,6 +24712,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"

--- a/src/components/multisig/proxy/offchain.ts
+++ b/src/components/multisig/proxy/offchain.ts
@@ -7,7 +7,6 @@ import {
 } from "@meshsdk/core";
 import type { UTxO, MeshTxBuilder } from "@meshsdk/core";
 // import { parseDatumCbor } from "@meshsdk/core-cst";
-import { DREP_DEPOSIT_STRING } from "@/utils/protocol-deposit-constants";
 import { parseProposalId } from "@/lib/governance";
 
 import { MeshTxInitiator } from "./common";
@@ -503,7 +502,7 @@ export class MeshProxyContract extends MeshTxInitiator {
         anchorDataHash: anchorHash!,
       });
     } else if (action === "deregister") {
-      txHex.drepDeregistrationCertificate(drepId, DREP_DEPOSIT_STRING);
+      txHex.drepDeregistrationCertificate(drepId);
     } else if (action === "update") {
       txHex.drepUpdateCertificate(drepId, {
         anchorUrl: anchorUrl!,

--- a/src/components/pages/wallet/governance/drep/retire.tsx
+++ b/src/components/pages/wallet/governance/drep/retire.tsx
@@ -13,7 +13,6 @@ import { MeshProxyContract } from "@/components/multisig/proxy/offchain";
 import { api } from "@/utils/api";
 import { useCallback } from "react";
 import { useToast } from "@/hooks/use-toast";
-import { DREP_DEPOSIT_STRING } from "@/utils/protocol-deposit-constants";
 import useActiveWallet from "@/hooks/useActiveWallet";
 
 export default function Retire({ appWallet, manualUtxos }: { appWallet: Wallet; manualUtxos: UTxO[] }) {
@@ -243,7 +242,7 @@ export default function Retire({ appWallet, manualUtxos }: { appWallet: Wallet; 
       txBuilder
         .txInScript(scriptCbor)
         .changeAddress(changeAddress)
-        .drepDeregistrationCertificate(dRepId, DREP_DEPOSIT_STRING);
+        .drepDeregistrationCertificate(dRepId);
       
       // Only add certificateScript if it's different from the spending script
       // to avoid "extraneous scripts" error

--- a/src/components/pages/wallet/staking/StakingActions/stake.tsx
+++ b/src/components/pages/wallet/staking/StakingActions/stake.tsx
@@ -8,7 +8,6 @@ import { MultisigWallet } from "@/utils/multisigSDK";
 import { ToastAction } from "@radix-ui/react-toast";
 import { toast } from "@/hooks/use-toast";
 import { getTxBuilder } from "@/utils/get-tx-builder";
-import { STAKE_KEY_DEPOSIT } from "@/utils/protocol-deposit-constants";
 import useTransaction from "@/hooks/useTransaction";
 
 type StakingAction = "register" | "deregister" | "delegate" | "withdrawal" | "registerAndDelegate";
@@ -19,10 +18,6 @@ type StakingActionConfig = {
   successTitle: string;
   successMessage: string;
 };
-
-function shouldApplyStakeDeposit(action: StakingAction): boolean {
-  return action === "register" || action === "registerAndDelegate";
-}
 
 function buildStakingActionConfigs({
   txBuilder,
@@ -130,10 +125,6 @@ export default function StakeButton({
         rewards: stakingInfo.rewards,
       });
       const actionConfig = actionConfigs[action];
-
-      if (shouldApplyStakeDeposit(action)) {
-        txBuilder.protocolParams({ keyDeposit: STAKE_KEY_DEPOSIT });
-      }
 
       actionConfig.execute();
 

--- a/src/hooks/useTransaction.ts
+++ b/src/hooks/useTransaction.ts
@@ -4,7 +4,6 @@ import { useCallback } from "react";
 import { useSiteStore } from "@/lib/zustand/site";
 import useAppWallet from "./useAppWallet";
 import { MeshTxBuilder } from "@meshsdk/core";
-import { csl } from "@meshsdk/core-csl";
 import useActiveWallet from "./useActiveWallet";
 import {
   filterWitnessesToScripts,
@@ -13,127 +12,6 @@ import {
   submitTxWithScriptRecovery,
 } from "@/utils/txSignUtils";
 import { getProvider } from "@/utils/get-provider";
-import {
-  DREP_DEPOSIT_LOVELACE,
-  STAKE_KEY_DEPOSIT_LOVELACE,
-} from "@/utils/protocol-deposit-constants";
-
-function parseCoinToBigInt(value: unknown, fallback: bigint): bigint {
-  if (typeof value === "bigint") return value;
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return BigInt(Math.trunc(value));
-  }
-  if (typeof value === "string" && value.trim().length > 0) {
-    try {
-      return BigInt(value);
-    } catch {
-      return fallback;
-    }
-  }
-  return fallback;
-}
-
-function getCertificateCoinDelta(txBuilder: MeshTxBuilder): bigint {
-  const body = txBuilder.meshTxBuilderBody as {
-    certificates?: Array<{
-      certType?: {
-        type?: string;
-        coin?: string | number | bigint;
-        deposit?: string | number | bigint;
-      };
-    }>;
-  };
-  const certs = body.certificates ?? [];
-
-  let delta = 0n;
-  for (const cert of certs) {
-    const certType = cert?.certType?.type ?? "";
-    const normalized = certType.toLowerCase();
-    const certCoin = cert?.certType?.coin ?? cert?.certType?.deposit;
-
-    if (normalized.includes("drepregistration")) {
-      delta -= parseCoinToBigInt(certCoin, DREP_DEPOSIT_LOVELACE);
-      continue;
-    }
-    if (normalized.includes("drepderegistration")) {
-      delta += parseCoinToBigInt(certCoin, DREP_DEPOSIT_LOVELACE);
-      continue;
-    }
-
-    const isStakeRegister =
-      normalized.includes("registerstake") || normalized.includes("stakeregistration");
-    const isStakeDeregister =
-      normalized.includes("deregisterstake") ||
-      normalized.includes("unregisterstake") ||
-      normalized.includes("stakederegistration");
-
-    if (isStakeRegister) {
-      delta -= STAKE_KEY_DEPOSIT_LOVELACE;
-      continue;
-    }
-    if (isStakeDeregister) {
-      delta += STAKE_KEY_DEPOSIT_LOVELACE;
-    }
-  }
-
-  return delta;
-}
-
-function adjustTxForStakeKeyDeposit(
-  unsignedTxHex: string,
-  coinDelta: bigint,
-  changeAddress?: string,
-): string {
-  if (coinDelta === 0n) {
-    return unsignedTxHex;
-  }
-
-  const tx = csl.Transaction.from_hex(unsignedTxHex);
-  const bodyJson = JSON.parse(tx.body().to_json()) as {
-    outputs?: Array<{ address?: string; amount?: { coin?: string } }>;
-  };
-  const outputs = bodyJson.outputs ?? [];
-  if (outputs.length === 0) {
-    return unsignedTxHex;
-  }
-
-  let changeOutputIndex = -1;
-  if (changeAddress) {
-    for (let i = 0; i < outputs.length; i++) {
-      const output = outputs[i];
-      if (output?.address === changeAddress) {
-        changeOutputIndex = i;
-      }
-    }
-  }
-
-  if (changeOutputIndex < 0) {
-    changeOutputIndex = outputs.length - 1;
-  }
-
-  const changeOutput = outputs[changeOutputIndex];
-  const currentCoin = BigInt(changeOutput?.amount?.coin ?? "0");
-  if (!changeOutput?.amount?.coin) {
-    return unsignedTxHex;
-  }
-
-  const adjustedCoin = currentCoin + coinDelta;
-  if (adjustedCoin <= 0n) {
-    return unsignedTxHex;
-  }
-  changeOutput.amount.coin = adjustedCoin.toString();
-
-  const adjustedTxBody = csl.TransactionBody.from_json(JSON.stringify(bodyJson));
-  const adjustedTx = csl.Transaction.new(
-    adjustedTxBody,
-    csl.TransactionWitnessSet.from_bytes(tx.witness_set().to_bytes()),
-    tx.auxiliary_data(),
-  );
-  if (!tx.is_valid()) {
-    adjustedTx.set_is_valid(false);
-  }
-  return adjustedTx.to_hex();
-}
 
 export default function useTransaction() {
   const ctx = api.useUtils();
@@ -225,18 +103,7 @@ export default function useTransaction() {
         });
       }
 
-      let unsignedTx = await data.txBuilder.complete();
-
-      // Workaround for certificate txs where builder-produced change may not
-      // fully account for deposit charge/refund in downstream validation.
-      const certificateCoinDelta = getCertificateCoinDelta(data.txBuilder);
-      if (certificateCoinDelta !== 0n) {
-        unsignedTx = adjustTxForStakeKeyDeposit(
-          unsignedTx,
-          certificateCoinDelta,
-          appWallet.address,
-        );
-      }
+      const unsignedTx = await data.txBuilder.complete();
 
       if (!activeWallet) {
         throw new Error("No wallet available for signing transaction");

--- a/src/utils/get-tx-builder.ts
+++ b/src/utils/get-tx-builder.ts
@@ -1,6 +1,5 @@
 import { MeshTxBuilder } from "@meshsdk/core";
 import { getProvider } from "@/utils/get-provider";
-import { STAKE_KEY_DEPOSIT } from "@/utils/protocol-deposit-constants";
 // import { CSLSerializer } from "@meshsdk/core-csl";
 
 export function getTxBuilder(network: number) {
@@ -8,11 +7,6 @@ export function getTxBuilder(network: number) {
   const txBuilder = new MeshTxBuilder({
     fetcher: blockchainProvider,
     evaluator: blockchainProvider,
-    params: {
-      // Explicitly provide stake key deposit so certificate balancing
-      // remains deterministic even when fetcher protocol params vary.
-      keyDeposit: STAKE_KEY_DEPOSIT,
-    },
     // serializer: new CSLSerializer(),
     verbose: true,
   });

--- a/src/utils/protocol-deposit-constants.ts
+++ b/src/utils/protocol-deposit-constants.ts
@@ -1,5 +1,2 @@
-export const STAKE_KEY_DEPOSIT = 2_000_000;
-export const STAKE_KEY_DEPOSIT_LOVELACE = 2_000_000n;
+/** Display / UX only — transaction deposits come from Mesh (chain protocol params). */
 export const DREP_DEPOSIT = 500_000_000;
-export const DREP_DEPOSIT_LOVELACE = 500_000_000n;
-export const DREP_DEPOSIT_STRING = "500000000";


### PR DESCRIPTION
Eliminated unused deposit constants from protocol-deposit-constants.ts and related files. Updated transaction handling to remove references to DREP_DEPOSIT_STRING and STAKE_KEY_DEPOSIT, simplifying the transaction logic in offchain.ts, retire.tsx, stake.tsx, and useTransaction.ts. This change removes a bug and enhances code clarity and reduces unnecessary complexity.