### PR TITLE
fix: guard against invalid CBOR in addTransaction and transaction card

### DIFF
--- a/src/__tests__/addTransaction.test.ts
+++ b/src/__tests__/addTransaction.test.ts
@@ -1,0 +1,246 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// --- mocks ---------------------------------------------------------------
+
+const addCorsCacheBustingHeadersMock = jest.fn<(res: NextApiResponse) => void>();
+const corsMock = jest.fn<(req: NextApiRequest, res: NextApiResponse) => Promise<void>>();
+
+jest.mock(
+  '@/lib/cors',
+  () => ({
+    __esModule: true,
+    addCorsCacheBustingHeaders: addCorsCacheBustingHeadersMock,
+    cors: corsMock,
+  }),
+  { virtual: true },
+);
+
+const verifyJwtMock = jest.fn<(token: string | undefined) => { address: string } | null>();
+const isBotJwtMock = jest.fn<(payload: unknown) => boolean>();
+
+jest.mock(
+  '@/lib/verifyJwt',
+  () => ({
+    __esModule: true,
+    verifyJwt: verifyJwtMock,
+    isBotJwt: isBotJwtMock,
+  }),
+  { virtual: true },
+);
+
+const applyRateLimitMock = jest.fn<
+  (req: NextApiRequest, res: NextApiResponse, options?: unknown) => boolean
+>();
+const applyBotRateLimitMock = jest.fn<
+  (req: NextApiRequest, res: NextApiResponse, botId: string) => boolean
+>();
+const enforceBodySizeMock = jest.fn<
+  (req: NextApiRequest, res: NextApiResponse, maxBytes: number) => boolean
+>();
+
+jest.mock(
+  '@/lib/security/requestGuards',
+  () => ({
+    __esModule: true,
+    applyRateLimit: applyRateLimitMock,
+    applyBotRateLimit: applyBotRateLimitMock,
+    enforceBodySize: enforceBodySizeMock,
+  }),
+  { virtual: true },
+);
+
+const assertBotWalletAccessMock = jest.fn<
+  (db: unknown, walletId: string, payload: unknown, ...rest: unknown[]) => Promise<{ wallet: unknown }>
+>();
+
+jest.mock(
+  '@/lib/auth/botAccess',
+  () => ({
+    __esModule: true,
+    assertBotWalletAccess: assertBotWalletAccessMock,
+  }),
+  { virtual: true },
+);
+
+const dbTransactionCreateMock = jest.fn<(args: unknown) => Promise<unknown>>();
+const dbWalletFindUniqueMock = jest.fn<(args: unknown) => Promise<unknown>>();
+
+const dbMock = {
+  transaction: { create: dbTransactionCreateMock },
+  wallet: { findUnique: dbWalletFindUniqueMock },
+};
+
+jest.mock(
+  '@/server/db',
+  () => ({
+    __esModule: true,
+    db: dbMock,
+  }),
+  { virtual: true },
+);
+
+const getProviderMock = jest.fn<(network: number) => { submitTx: (cbor: string) => unknown }>();
+
+jest.mock(
+  '@/utils/get-provider',
+  () => ({
+    __esModule: true,
+    getProvider: getProviderMock,
+  }),
+  { virtual: true },
+);
+
+const transactionFromHexMock = jest.fn<(hex: string) => { _parsed: true }>();
+
+jest.mock(
+  '@meshsdk/core-csl',
+  () => ({
+    __esModule: true,
+    csl: {
+      Transaction: { from_hex: transactionFromHexMock },
+    },
+  }),
+  { virtual: true },
+);
+
+// --- helpers -------------------------------------------------------------
+
+type ResponseMock = NextApiResponse & { statusCode?: number };
+
+function createMockResponse(): ResponseMock {
+  const res = {
+    statusCode: undefined as number | undefined,
+    status: jest.fn<(code: number) => NextApiResponse>(),
+    json: jest.fn<(payload: unknown) => unknown>(),
+    end: jest.fn<() => void>(),
+    setHeader: jest.fn<(name: string, value: string) => void>(),
+  };
+
+  res.status.mockImplementation((code: number) => {
+    res.statusCode = code;
+    return res as unknown as NextApiResponse;
+  });
+
+  res.json.mockImplementation((payload: unknown) => payload);
+
+  return res as unknown as ResponseMock;
+}
+
+const VALID_CBOR = '84a3'.padEnd(64, '0');
+const ADDRESS = 'addr_test1qpcallerexample';
+const WALLET_ID = 'wallet-id-1';
+const TOKEN = 'caller-token';
+
+function baseBody(overrides: Record<string, unknown> = {}) {
+  return {
+    walletId: WALLET_ID,
+    address: ADDRESS,
+    txCbor: VALID_CBOR,
+    txJson: JSON.stringify({ outputs: [] }),
+    description: 'test tx',
+    ...overrides,
+  };
+}
+
+function buildReq(body: Record<string, unknown>): NextApiRequest {
+  return {
+    method: 'POST',
+    headers: { authorization: `Bearer ${TOKEN}` },
+    body,
+  } as unknown as NextApiRequest;
+}
+
+let handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void | NextApiResponse>;
+
+beforeAll(async () => {
+  ({ default: handler } = await import('../pages/api/v1/addTransaction'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  corsMock.mockResolvedValue(undefined);
+  addCorsCacheBustingHeadersMock.mockImplementation(() => undefined);
+  applyRateLimitMock.mockReturnValue(true);
+  applyBotRateLimitMock.mockReturnValue(true);
+  enforceBodySizeMock.mockReturnValue(true);
+  verifyJwtMock.mockReturnValue({ address: ADDRESS });
+  isBotJwtMock.mockReturnValue(false);
+  transactionFromHexMock.mockReturnValue({ _parsed: true });
+  dbWalletFindUniqueMock.mockResolvedValue({
+    id: WALLET_ID,
+    type: 'atLeast',
+    numRequiredSigners: 2,
+    signersAddresses: [ADDRESS],
+  });
+  dbTransactionCreateMock.mockResolvedValue({ id: 'new-tx-id' });
+});
+
+// --- tests ---------------------------------------------------------------
+
+describe('addTransaction API route validation', () => {
+  it('rejects malformed CBOR with 400 and does not write to the DB', async () => {
+    transactionFromHexMock.mockImplementation(() => {
+      throw new Error('cbor deserialization failed');
+    });
+
+    const res = createMockResponse();
+    await handler(buildReq(baseBody({ txCbor: 'deadbeef' })), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining('Invalid transaction CBOR'),
+      }),
+    );
+    expect(dbTransactionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-string txCbor with 400', async () => {
+    const res = createMockResponse();
+    await handler(buildReq(baseBody({ txCbor: 12345 })), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining('Invalid txCbor'),
+      }),
+    );
+    expect(transactionFromHexMock).not.toHaveBeenCalled();
+    expect(dbTransactionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects unparseable txJson string with 400', async () => {
+    const res = createMockResponse();
+    await handler(buildReq(baseBody({ txJson: '{not json' })), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining('Invalid txJson'),
+      }),
+    );
+    expect(dbTransactionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('persists the transaction when CBOR and JSON are both valid', async () => {
+    const res = createMockResponse();
+    await handler(buildReq(baseBody()), res);
+
+    expect(transactionFromHexMock).toHaveBeenCalledWith(VALID_CBOR);
+    expect(dbTransactionCreateMock).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('accepts a txJson that is already an object', async () => {
+    const res = createMockResponse();
+    await handler(
+      buildReq(baseBody({ txJson: { outputs: [], certificates: [] } })),
+      res,
+    );
+
+    expect(dbTransactionCreateMock).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+});

--- a/src/components/pages/wallet/transactions/transaction-card.tsx
+++ b/src/components/pages/wallet/transactions/transaction-card.tsx
@@ -73,7 +73,15 @@ export default function TransactionCard({
   const { activeWallet, isWalletReady, isAnyWalletConnected } = useActiveWallet();
   const { appWallet } = useAppWallet();
   const userAddress = useUserStore((state) => state.userAddress);
-  const txJson = JSON.parse(transaction.txJson);
+  // Parse defensively — a malformed txJson (e.g. from a row that slipped past
+  // earlier API validation) must not crash the whole Transactions page (#211).
+  const txJson = useMemo<any>(() => {
+    try {
+      return JSON.parse(transaction.txJson);
+    } catch {
+      return null;
+    }
+  }, [transaction.txJson]);
   const [loading, setLoading] = useState<boolean>(false);
   const [isSignersOpen, setIsSignersOpen] = useState<boolean>(false);
   const { toast } = useToast();
@@ -371,6 +379,9 @@ export default function TransactionCard({
   // }, []);
 
   const outputList = useMemo((): React.ReactElement => {
+    if (!txJson || !Array.isArray(txJson.outputs)) {
+      return <></>;
+    }
     return (
       <>
         {txJson.outputs.map((output: any, i: number) => {
@@ -477,7 +488,51 @@ export default function TransactionCard({
   }
 
   if (!appWallet) return <></>;
-  
+
+  // Unreadable transaction — txJson failed to parse. Render a degraded card so
+  // the Transactions page still loads and the user can free locked UTxOs (#211).
+  if (!txJson) {
+    return (
+      <Card className="self-start overflow-hidden w-full border-destructive/40">
+        <CardHeader className="flex flex-col gap-3 bg-destructive/5 p-4 sm:p-6">
+          <CardTitle className="text-base sm:text-lg">
+            Unreadable transaction
+          </CardTitle>
+          <CardDescription className="text-xs sm:text-sm">
+            {dateToFormatted(transaction.createdAt)}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-4 sm:p-6 text-sm space-y-3">
+          <p className="text-muted-foreground">
+            This transaction&apos;s metadata could not be parsed and cannot be
+            signed. Rejecting it here will free any UTxOs it was holding.
+          </p>
+          <div className="text-xs font-mono text-muted-foreground break-all">
+            <div>
+              <span className="font-semibold">ID:</span> {transaction.id}
+            </div>
+            {transaction.txHash && (
+              <div>
+                <span className="font-semibold">Tx hash:</span>{" "}
+                {transaction.txHash}
+              </div>
+            )}
+          </div>
+        </CardContent>
+        <CardFooter className="flex items-center justify-end border-t bg-muted/50 px-4 sm:px-6 py-3">
+          <Button
+            variant="destructive"
+            onClick={() => deleteTx()}
+            disabled={loading}
+            loading={loading}
+          >
+            Reject & Delete
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
   // Calculate signing threshold info
   const signersCount = appWallet.signersAddresses.length;
   const requiredSigners = appWallet.numRequiredSigners ?? signersCount;

--- a/src/pages/api/v1/addTransaction.ts
+++ b/src/pages/api/v1/addTransaction.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { csl } from "@meshsdk/core-csl";
 import { db } from "@/server/db";
 import { verifyJwt, isBotJwt } from "@/lib/verifyJwt";
 import { cors, addCorsCacheBustingHeaders } from "@/lib/cors";
@@ -73,6 +74,28 @@ export default async function handler(
   }
   if (!txJson) {
     return res.status(400).json({ error: "Missing required field txJson!" });
+  }
+
+  // Reject unparseable CBOR/JSON up front so we never persist a row that
+  // the transactions page or the Cardano node cannot deserialize (#211).
+  if (typeof txCbor !== "string") {
+    return res.status(400).json({ error: "Invalid txCbor: must be a hex string" });
+  }
+  try {
+    csl.Transaction.from_hex(txCbor);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return res.status(400).json({ error: `Invalid transaction CBOR: ${msg}` });
+  }
+  if (typeof txJson === "string") {
+    try {
+      JSON.parse(txJson);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return res.status(400).json({ error: `Invalid txJson: ${msg}` });
+    }
+  } else if (typeof txJson !== "object" || txJson === null) {
+    return res.status(400).json({ error: "Invalid txJson: must be a JSON object or string" });
   }
 
   let wallet: { id: string; signersAddresses: string[]; numRequiredSigners: number | null; type: string };


### PR DESCRIPTION
## Summary

Two-part defense against the bug reported in #211, where a transaction added via `POST /api/v1/addTransaction` with a non-standard 4-element CBOR wrapper was persisted as-is, then later crashed the Transactions page for the wallet — locking up its UTxOs with no way to recover because the Delete button lived on the same page that was crashing.

- `src/pages/api/v1/addTransaction.ts`: reject unparseable `txCbor` (via `csl.Transaction.from_hex`) and unparseable `txJson` up front with HTTP 400, so no more malformed rows can be created.
- `src/components/pages/wallet/transactions/transaction-card.tsx`: wrap `JSON.parse(transaction.txJson)` in `try/catch`. On failure, render a degraded "Unreadable transaction" card that still exposes a Reject & Delete button wired to the existing `deleteTransaction` mutation, so already-poisoned wallets can recover.
- Adds `src/__tests__/addTransaction.test.ts` covering the four new validation branches plus the happy path.

Closes #211

## Test plan

- [x] `npx jest src/__tests__/addTransaction.test.ts` — 5/5 pass
- [x] Full `npx jest` — no new failures introduced (pre-existing unrelated failures in `apiSecurity`, `botBallotsUpsert`, `governanceActiveProposals`, `multisigSDK`, `signTransaction` remain)
- [x] `npx tsc --noEmit` — no new errors on touched files
- [ ] Manual: `POST /api/v1/addTransaction` with junk `txCbor` → 400 `{error: "Invalid transaction CBOR: ..."}`
- [ ] Manual (preprod): open the Transactions page for a wallet with a known bad row (e.g. `cmmoyccbt0003le04veswn9b5`, `cmmuuxyg40001l204bmcb6jim` from #211) and confirm the page loads, the bad row shows the degraded card, and Reject & Delete frees its UTxOs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)