### PR TITLE
chore(ci): gate typecheck/test/build; add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      mesh-sdk:
+        patterns:
+          - "@meshsdk/*"
+      next:
+        patterns:
+          - "next"
+          - "next-*"
+          - "@next/*"
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/*"
+      trpc:
+        patterns:
+          - "@trpc/*"
+      types:
+        patterns:
+          - "@types/*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,20 +29,19 @@ jobs:
       - name: Generate Prisma client
         run: npx prisma generate
 
+      # Lint stays non-blocking until the rule set is cleaned up; tracked separately.
       - name: Lint
         run: npm run lint
         continue-on-error: true
 
+      # Typecheck, test, and build are gates — failures must fail the PR.
       - name: Type check
         run: npx tsc --noEmit
-        continue-on-error: true
 
       - name: Test
         run: npm run test:ci
-        continue-on-error: true
 
       - name: Build
         run: npm run build
         env:
           SKIP_ENV_VALIDATION: 'true'
-        continue-on-error: true


### PR DESCRIPTION
## Summary
- Drop `continue-on-error` from typecheck, test, and build steps in `pr-checks.yml`. They were silently passing — gates that only report status without blocking aren't gates.
- Keep `continue-on-error` on lint until the rule set is cleaned up (tracked separately).
- Add `.github/dependabot.yml` with weekly npm + monthly github-actions schedules, grouped by ecosystem (`@meshsdk/*`, `next`/`@next/*`, `prisma`/`@prisma/*`, `@trpc/*`, `@types/*`).

## Why now
The repo currently has typecheck-clean and test-clean state on `main` (verified locally: tsc passes, 171/171 tests deterministic across two runs, `next build` succeeds). Turning the gates on now is safe and prevents regressions from sneaking in via future PRs.

## Test plan
- [ ] CI runs on this PR and all three gates execute
- [ ] Typecheck step reports its real status (not auto-success)
- [ ] Test step reports its real status
- [ ] Build step reports its real status
- [ ] Lint may report failures but does not block merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)