### PR TITLE
fix(build): lazy-init mainnet provider; drop global sideEffects:false

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -55,13 +55,16 @@ const config = {
       layers: true,
     };
     
-    // Optimize tree-shaking by ensuring proper module resolution
+    // Optimize tree-shaking by ensuring proper module resolution.
+    // Note: do NOT set `sideEffects: false` globally — it tells webpack that
+    // every file is side-effect-free, which silently strips CSS imports,
+    // polyfills, and other modules that exist purely for their side effects.
+    // Per-package sideEffects flags in package.json are the correct surface.
     config.optimization = {
       ...config.optimization,
       usedExports: true,
-      sideEffects: false,
     };
-    
+
     // Handle CommonJS modules that don't support named exports
     config.resolve = {
       ...config.resolve,

--- a/src/components/common/cardano-objects/resolve-adahandle.tsx
+++ b/src/components/common/cardano-objects/resolve-adahandle.tsx
@@ -1,8 +1,14 @@
 import { toast } from "@/hooks/use-toast";
 import { getProvider } from "@/utils/get-provider";
 
-//AdaHandle look up provider only supports mainnnet
-const provider = getProvider(1)
+// AdaHandle lookup is mainnet-only. Lazy-init the provider so the module
+// can be imported during SSR / page-data collection without requiring
+// NEXT_PUBLIC_BLOCKFROST_API_KEY_MAINNET to be defined at module-load time.
+let cachedProvider: ReturnType<typeof getProvider> | null = null;
+const getMainnetProvider = () => {
+  if (!cachedProvider) cachedProvider = getProvider(1);
+  return cachedProvider;
+};
 
 export const resolveAdaHandle = async (
   setAdaHandle: (value: string) => void,
@@ -18,7 +24,7 @@ export const resolveAdaHandle = async (
       return;
     }
 
-    const address = await provider.fetchHandleAddress(handleName);
+    const address = await getMainnetProvider().fetchHandleAddress(handleName);
 
     if (address) {
       const newAddresses = [...recipientAddresses];

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,6 +13,7 @@ import { env } from "@/env";
 import { api } from "@/utils/api";
 
 import "@/styles/globals.css";
+import "swagger-ui-react/swagger-ui.css";
 import "@/styles/swagger-overrides.css";
 import { Toaster } from "@/components/ui/toaster";
 import Metatags from "@/components/ui/metatags";

--- a/src/pages/api-docs.tsx
+++ b/src/pages/api-docs.tsx
@@ -6,8 +6,9 @@ import { Key, Lightbulb, Copy, Check } from "lucide-react";
 import Globe from "./globe";
 
 // Avoid SSR for Swagger UI
+// Note: swagger-ui CSS is imported globally from src/pages/_app.tsx because
+// Next.js Pages Router only allows global CSS imports from the custom App.
 const SwaggerUI = dynamic(() => import("swagger-ui-react"), { ssr: false });
-import "swagger-ui-react/swagger-ui.css";
 
 export const getServerSideProps = () => ({ props: {} });
 


### PR DESCRIPTION
## Summary
Two interacting bugs caused `next build --webpack` to crash on routes that imported `resolve-adahandle` (notably `/wallets/[wallet]/transactions/new`):

1. **Top-level provider construction.** `resolve-adahandle.tsx:5` called `getProvider(1)` at module load. During `next build` page-data collection every SSR'd page imports that module, which constructs `BlockfrostProvider(undefined)` when `NEXT_PUBLIC_BLOCKFROST_API_KEY_MAINNET` isn't readable at build time (`SKIP_ENV_VALIDATION=true`). The constructor throws; webpack reports it as a generic "factory error".

2. **Global `sideEffects: false`.** `next.config.js` had `optimization.sideEffects: false` set on the global webpack config. That tells webpack *every* file is side-effect-free, silently stripping global CSS imports and module-level init — and masking the real crash from (1) until a caller exercised the code path.

## Fix
- `resolve-adahandle.tsx` — lazy-init singleton: `getProvider(1)` runs only when `resolveAdaHandle()` is actually called (client-side).
- `next.config.js` — remove the global `sideEffects: false` override. Per-package `sideEffects` flags in each `package.json` are the correct surface.
- `_app.tsx` / `api-docs.tsx` — move `swagger-ui-react/swagger-ui.css` import into the custom App, since Pages Router only allows global CSS imports from `_app.tsx`.

## Test plan
- [ ] `next build --webpack` completes without errors
- [ ] `/wallets/[wallet]/transactions/new` renders (was failing before)
- [ ] `/api-docs` renders Swagger UI with styles intact
- [ ] No regressions on other routes

Verified locally: production build completes (exit 0), all routes generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)