### PR TITLE
fix(wallet-assets): show actual IPFS NFT image instead of hardcoded CID

### DIFF
--- a/src/components/pages/wallet/assets/wallet-assets.tsx
+++ b/src/components/pages/wallet/assets/wallet-assets.tsx
@@ -84,12 +84,10 @@ export default function WalletAssets({ appWallet }: { appWallet: Wallet }) {
               >
                 {isImageIpfs ? (
                   <IPFSImage
-                    src={
-                      "ipfs://QmSNkaU4DW3asABKyUfSx3ykFAtV5PuXLsXu63nMUo8HGv"
-                    }
-                    alt="IPFS Image"
-                    width={300}
-                    height={300}
+                    src={imageSrc}
+                    alt={name}
+                    width={60}
+                    height={60}
                   />
                 ) : (
                   <Image


### PR DESCRIPTION
## Summary

User-visible bug: every IPFS-based NFT in the wallet asset list rendered the **same hardcoded placeholder image** instead of its own metadata. The IPFS branch of the asset card was hardcoded to `ipfs://QmSNkaU4DW3asABKyUfSx3ykFAtV5PuXLsXu63nMUo8HGv` and ignored `imageSrc` (which holds the asset's actual `metadata.image`).

The non-IPFS sibling already uses `imageSrc` / `name` / `60×60` correctly — this brings the IPFS branch in line.

**Severity:** HIGH (user-visible, all IPFS NFTs affected)
**Introduced:** 2025-03-27 (single occurrence in the codebase)

### Changes
- `src={"ipfs://Qm..."}` → `src={imageSrc}` — show the actual asset's IPFS URL
- `alt="IPFS Image"` → `alt={name}` — a11y, screen readers now announce the NFT name
- `width={300} height={300}` → `width={60} height={60}` — matches parent 60×60 div (was being clipped by `overflow-hidden` and wasted bandwidth)

## Test plan

- [ ] Open a wallet that holds an IPFS-based NFT
- [ ] Verify the NFT thumbnail shows its actual artwork (not the placeholder cat)
- [ ] Verify hover/screen-reader announces the asset name
- [ ] Verify image fits the 60×60 frame cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)