### PR TITLE
chore(proxy): remove three write-only useState declarations

### DIFF
--- a/src/components/multisig/proxy/ProxyControl.tsx
+++ b/src/components/multisig/proxy/ProxyControl.tsx
@@ -122,7 +122,6 @@ export default function ProxyControl() {
   // State management
   const [proxyContract, setProxyContract] = useState<MeshProxyContract | null>(null);
   const [isProxySetup, setIsProxySetup] = useState<boolean>(false);
-  const [, setLocalLoading] = useState<boolean>(false);
   const [tvlLoading, setTvlLoading] = useState<boolean>(false);
 
   // Setup flow state
@@ -148,10 +147,6 @@ export default function ProxyControl() {
   const [spendOutputs, setSpendOutputs] = useState<ProxyOutput[]>([
     { address: "", unit: "lovelace", amount: "" }
   ]);
-
-  // UTxO selection state (UI only). We will still pass all UTxOs from provider to contract.
-  const [, setSelectedUtxos] = useState<UTxO[]>([]);
-  const [, setManualSelected] = useState<boolean>(false);
 
   // Helper to resolve inputs for multisig controlled txs
   const getMsInputs = useCallback(async (): Promise<{ utxos: UTxO[]; walletAddress: string }> => {
@@ -264,8 +259,7 @@ export default function ProxyControl() {
 
     try {
       setSetupLoading(true);
-      setLocalLoading(true);
-      
+
       // Reset setup data to prevent conflicts with previous attempts
       setSetupData({});
       setSetupStep(0);
@@ -301,7 +295,6 @@ export default function ProxyControl() {
       });
     } finally {
       setSetupLoading(false);
-      setLocalLoading(false);
     }
   }, [proxyContract, isWalletReady, getMsInputs, newTransaction, toast]);
 
@@ -318,7 +311,6 @@ export default function ProxyControl() {
 
     try {
       setSetupLoading(true);
-      setLocalLoading(true);
 
       // If msCbor is set, route through useTransaction hook to create a signable
       if (appWallet?.scriptCbor && setupData.txHex) {
@@ -395,7 +387,6 @@ export default function ProxyControl() {
       });
     } finally {
       setSetupLoading(false);
-      setLocalLoading(false);
     }
   }, [setupData, activeWallet, appWallet, createProxy, refetchProxies, getMsInputs, newTransaction, userAddress, toast]);
 
@@ -600,7 +591,6 @@ export default function ProxyControl() {
 
     try {
       setSpendLoading(true);
-      setLocalLoading(true);
 
       // Get the selected proxy
       const proxy = proxies?.find((p: { id: string }) => p.id === selectedProxyId);
@@ -672,7 +662,6 @@ export default function ProxyControl() {
       });
     } finally {
       setSpendLoading(false);
-      setLocalLoading(false);
     }
   }, [proxyContract, isWalletReady, spendOutputs, selectedProxyId, proxies, network, activeWallet, handleProxySelection, getMsInputs, newTransaction, appWallet?.scriptCbor, toast]);
 
@@ -840,9 +829,9 @@ export default function ProxyControl() {
                   <UTxOSelector
                     appWallet={appWallet}
                     network={network}
-                    onSelectionChange={(utxos, manual) => {
-                      setSelectedUtxos(utxos);
-                      setManualSelected(manual);
+                    onSelectionChange={() => {
+                      // Selection is for user visibility only;
+                      // contract uses all UTxOs from the multisig wallet.
                     }}
                   />
                 </div>


### PR DESCRIPTION
## Summary

`ProxyControl` had three state variables whose values were destructured away — only the setters were called. Each setter call triggered an empty re-render with nothing downstream reading the value.

| State | Setter called from | Live signal that replaces it |
|---|---|---|
| `setLocalLoading` | 6 paired sites alongside `setSetupLoading` / `setSpendLoading` | `setupLoading` / `spendLoading` (already used in JSX) |
| `setSelectedUtxos` | `<UTxOSelector onSelectionChange>` callback | None — selection is purely visual; contract uses all UTxOs |
| `setManualSelected` | same callback | same |

The `UTxOSelector.onSelectionChange` prop is required (`(selectedUtxos, manualSelected) => void` not optional), so the callback is preserved as a no-op with an inline comment explaining the visual-only intent. Changing the prop to optional would be a wider refactor across multiple callers (`new-transaction/index.tsx`, `staking/StakingActions/stakingActionCard.tsx`, `governance/index.tsx`) and is out of scope here.

**Net diff:** 4 insertions, 15 deletions. Zero behavior change.

## Test plan

- [ ] Open a wallet with a proxy contract — proxy section renders
- [ ] Run "Initialize Setup" — setup loading spinner shows during async
- [ ] Run "Confirm Setup" — same loading behavior
- [ ] Run "Spend from Proxy" — spend loading spinner shows during async
- [ ] Toggle UTxOs in the UTxOSelector — UI responds (visual-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)