### PR TITLE
chore(dependabot): target preprod for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "preprod"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -33,6 +34,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "preprod"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
## What

Adds `target-branch: "preprod"` to both `updates:` entries (npm + github-actions) in `.github/dependabot.yml`.

## Why

The team's release flow is **preprod → main** (see #229 / #261). Dependency bumps should land on `preprod` first like everything else, rather than opening directly against `main`.

Note: Dependabot reads its config from the **default branch (`main`)**, so this change must merge to `main` to take effect — but future PRs it generates will target `preprod`.

The 9 currently-open Dependabot PRs have already been re-pointed to `preprod` manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)