### PR TITLE
fix(test): jest.resetModules in freeUtxos bot test to clear cached real impl

### DIFF
--- a/src/__tests__/freeUtxos.bot.test.ts
+++ b/src/__tests__/freeUtxos.bot.test.ts
@@ -97,6 +97,14 @@ jest.mock("@/lib/security/rateLimit", () => ({
 let handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void | NextApiResponse>;
 
 beforeAll(async () => {
+  // Other suites (notably nativeScriptUtils.test.ts) import the real
+  // @/utils/nativeScriptUtils and @/utils/common before this file runs;
+  // Jest caches those modules and the jest.mock(..., {virtual:true})
+  // declarations above don't re-wire the bindings inside transitively
+  // imported files like @/lib/server/walletScriptAddress. Resetting the
+  // registry forces the dynamic handler import below to pick up our
+  // mocked versions instead of the cached reals.
+  jest.resetModules();
   ({ default: handler } = await import("../pages/api/v1/freeUtxos"));
 });
 


### PR DESCRIPTION
## Why
The \`checks\` job on [#229](https://github.com/MeshJS/multisig/pull/229) failed with 3 flakes in \`src/__tests__/freeUtxos.bot.test.ts\`:

- \`falls back to canonical scriptCbor when multisig wallet is unavailable\` — \`decodeNativeScriptFromCbor\` never observed as called
- \`returns clear 500 when canonical script fallback cannot decode\` — error message is "unknown error" instead of the mocked "invalid canonical cbor"

In isolation (\`jest src/__tests__/freeUtxos.bot.test.ts\`) all 4 tests pass. In the full suite, those 3 fail.

## Root cause
\`src/__tests__/nativeScriptUtils.test.ts\` imports the **real** \`@/utils/nativeScriptUtils\` (no mock) and Jest caches it in the module registry. When \`freeUtxos.bot.test.ts\` runs later, its top-level \`jest.mock("@/utils/nativeScriptUtils", () => …, { virtual: true })\` doesn't re-wire the bindings inside the *transitively* imported \`@/lib/server/walletScriptAddress\` — those bindings already point at the real implementation. The mocks never fire, the real \`decodeNativeScriptFromCbor\` is invoked on the test fixture \`"canonical-cbor"\`, throws a non-Error, and the handler returns "unknown error".

## Fix
A single \`jest.resetModules()\` in \`beforeAll\` before the dynamic handler import forces a fresh module graph that honors this suite's mocks.

## Verification
\`\`\`
$ npx jest
Test Suites: 1 skipped, 46 passed, 46 of 47 total
Tests:       2 skipped, 357 passed, 359 total
\`\`\`
(was 1 failed / 3 tests failing before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)