### PR TITLE
diag: instrument ballot vote witness/body-hash divergence

### DIFF
--- a/src/pages/api/v1/signTransaction.ts
+++ b/src/pages/api/v1/signTransaction.ts
@@ -334,6 +334,26 @@ export default async function handler(
       }
     }
 
+    // [ballot-witness-diag] Detect whether merging/rebuilding the tx changed the
+    // body the signatures were made over. `txHashHex` is the body hash the
+    // incoming witness was verified against (line ~245). If the final tx hashes
+    // differently, every collected witness is now stale → InvalidWitnessesUTXOW.
+    try {
+      const finalBodyHash = calculateTxHash(txHexForUpdate).toLowerCase();
+      if (finalBodyHash !== txHashHex) {
+        console.warn("[ballot-witness-diag] tx body hash changed after witness merge", {
+          transactionId,
+          storedBodyHash: txHashHex,
+          finalBodyHash,
+        });
+      }
+    } catch (diagError: unknown) {
+      console.warn(
+        "[ballot-witness-diag] failed to compute final body hash",
+        toError(diagError),
+      );
+    }
+
     const witnessSummaries: {
       keyHashHex: string;
       publicKeyBech32: string;

--- a/src/utils/txScriptRecovery.ts
+++ b/src/utils/txScriptRecovery.ts
@@ -3,7 +3,7 @@ import {
   deserializeAddress,
   serializeNativeScript,
 } from "@meshsdk/core";
-import { csl, deserializeNativeScript } from "@meshsdk/core-csl";
+import { csl, deserializeNativeScript, calculateTxHash } from "@meshsdk/core-csl";
 import type {
   MultisigSubmissionWallet,
   ScriptRecoveryWallet,
@@ -493,6 +493,37 @@ async function retrySubmitWithCandidateScriptSets(
   throw lastRetryError;
 }
 
+/**
+ * [ballot-witness-diag] Diagnostic only — no behaviour change.
+ * Recomputes the body hash of the exact tx we are about to submit and checks
+ * every vkey witness against it. Any witness that fails here is signed over a
+ * different body encoding than the one reaching the node — the root cause of
+ * `InvalidWitnessesUTXOW` on Conway ballot/vote transactions.
+ */
+export function diagnoseTxWitnesses(txHex: string): {
+  bodyHash: string;
+  total: number;
+  stale: { pubKeyHex: string; keyHashHex: string }[];
+} {
+  const tx = csl.Transaction.from_hex(txHex);
+  const bodyHash = calculateTxHash(txHex).toLowerCase();
+  const bodyHashBytes = Buffer.from(bodyHash, "hex");
+  const vkeys = tx.witness_set().vkeys();
+  const total = vkeys ? vkeys.len() : 0;
+  const stale: { pubKeyHex: string; keyHashHex: string }[] = [];
+  for (let i = 0; i < total; i++) {
+    const w = vkeys!.get(i);
+    const pk = w.vkey().public_key();
+    if (!pk.verify(bodyHashBytes, w.signature())) {
+      stale.push({
+        pubKeyHex: bytesToHex(pk.as_bytes()),
+        keyHashHex: bytesToHex(pk.hash().to_bytes()),
+      });
+    }
+  }
+  return { bodyHash, total, stale };
+}
+
 export async function submitTxWithScriptRecovery({
   txHex,
   submitter,
@@ -500,6 +531,22 @@ export async function submitTxWithScriptRecovery({
   network,
 }: SubmitTxWithRecoveryArgs): Promise<SubmitTxWithRecoveryResult> {
   try {
+    try {
+      const diag = diagnoseTxWitnesses(txHex);
+      if (diag.stale.length > 0) {
+        console.warn(
+          "[ballot-witness-diag] vkey witness(es) do NOT verify against the submit body — node will reject with InvalidWitnessesUTXOW",
+          {
+            submitBodyHash: diag.bodyHash,
+            totalWitnesses: diag.total,
+            staleWitnesses: diag.stale,
+          },
+        );
+      }
+    } catch (diagError) {
+      console.warn("[ballot-witness-diag] pre-submit diagnostic failed", diagError);
+    }
+
     const txHash = await submitter.submitTx(txHex);
     return { txHash, txHex, repaired: false };
   } catch (submitError) {

--- a/src/utils/txSignUtils.ts
+++ b/src/utils/txSignUtils.ts
@@ -164,10 +164,24 @@ export function mergeSignerWitnesses(
   const signedTx = extractFullSignedTx(signedPayloadHex);
   const existingVkeysCount = originalTx.witness_set().vkeys()?.len() ?? 0;
   let bodyToUse = csl.TransactionBody.from_bytes(originalTx.body().to_bytes());
-  if (signedTx && existingVkeysCount === 0) {
+  if (signedTx) {
     const walletBodyBytes = Buffer.from(signedTx.body().to_bytes());
-    if (!originalBodyBytes.equals(walletBodyBytes)) {
+    const bodiesDiffer = !originalBodyBytes.equals(walletBodyBytes);
+    if (bodiesDiffer && existingVkeysCount === 0) {
+      // [ballot-witness-diag] First signer: adopt the wallet's re-canonicalised
+      // body so the signature matches (unchanged behaviour, now logged).
       bodyToUse = csl.TransactionBody.from_bytes(signedTx.body().to_bytes());
+      console.warn(
+        "[ballot-witness-diag] wallet re-canonicalised tx body; adopting wallet body (first signer)",
+      );
+    } else if (bodiesDiffer) {
+      // [ballot-witness-diag] Co-signer: body-swap is skipped because earlier
+      // witnesses exist, so this signature stays bound to the wallet's encoding
+      // and may be stale against the stored body we persist/submit.
+      console.warn(
+        "[ballot-witness-diag] wallet re-canonicalised tx body but existing witnesses present — co-signer witness may be stale against stored body",
+        { existingVkeysCount },
+      );
     }
   }
 


### PR DESCRIPTION
## Context

Submitting a **legacy-DRep ballot vote** fails at the node with:

```
ConwayUtxowFailure (InvalidWitnessesUTXOW [VKey (VerKeyEd25519DSIGN "ce7cbe8f…cc10b")])
```

The listed vkey witness is cryptographically valid — but over a **different tx-body hash** than the body that reaches the node. For ballots this is the classic Conway `voting_procedures` re-encoding problem: some wallets re-canonicalise the body before signing, so the witness targets *their* encoding, not the one we persist/submit.

## What this PR does

**Diagnostics only — no behaviour change.** Adds three `[ballot-witness-diag]` log points to confirm *exactly where* the body hash diverges before we change any consensus-critical logic.

- **`txScriptRecovery.ts`** — new `diagnoseTxWitnesses()` recomputes the body hash of the exact bytes about to be submitted and verifies every vkey witness against it. Logs any stale witness (pubkey + keyhash) immediately before `submitTx`. Fires on **both** signing paths.
- **`txSignUtils.ts` (`mergeSignerWitnesses`)** — logs wallet body re-canonicalisation, distinguishing first-signer (body adopted) from co-signer (body-swap skipped → witness may be stale).
- **`api/v1/signTransaction.ts`** — logs when merge/rebuild changes the body hash the collected signatures were made over.

## How to read the output

Reproduce the legacy-DRep ballot submit, then:
- **Creator / first-signer** submit → **browser console**
- **Co-signer** submit (API) → **server logs**

Interpretation:
- Pre-submit log lists `ce7cbe8f…` in `staleWitnesses` → confirms encoding mismatch; `submitBodyHash` is what the node hashed.
- "co-signer witness may be stale" → the gap is the first-signer-only body-swap.
- "body hash changed after witness merge" → the API rebuild is mutating the body.

## Follow-up (not in this PR)

Once the cause is confirmed, the recovery at `txScriptRecovery.ts` `InvalidWitnessesUTXOW` handling currently *drops* the offending witness and resubmits — which pushes a multisig native script under threshold and masks the real failure. That should be addressed after we have the diagnostic evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)