### PR TITLE
feat(governance): in-app Ekklesia/Hydra budget voting for multisig DRep

### DIFF
--- a/src/components/pages/wallet/governance/hydra/HydraBudgetVote.tsx
+++ b/src/components/pages/wallet/governance/hydra/HydraBudgetVote.tsx
@@ -1,0 +1,421 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useWallet } from "@meshsdk/react";
+import { Info, Loader, Check, X, ExternalLink } from "lucide-react";
+
+import useAppWallet from "@/hooks/useAppWallet";
+import useMultisigWallet from "@/hooks/useMultisigWallet";
+import { useUserStore } from "@/lib/zustand/user";
+import { api } from "@/utils/api";
+import { useToast } from "@/hooks/use-toast";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+
+import { fetchBallot } from "@/lib/ekklesia/client";
+import { BUDGET_2026_BALLOT_ID } from "@/lib/ekklesia/types";
+import type { EkklesiaWitness } from "@/lib/ekklesia/types";
+import {
+  authenticate,
+  buildVoteItems,
+  coSignVotePackage,
+  createVotePackage,
+  type VoteChoice,
+} from "@/lib/ekklesia/voteFlow";
+
+const EKKLESIA_METHOD = "ekklesia-vote";
+const EKKLESIA_UI = "https://intersect.ekklesia.vote";
+
+/** Persisted coordination payload (stored as the signable's `payload`). */
+interface EkklesiaSignablePayload {
+  kind: typeof EKKLESIA_METHOD;
+  ballotId: string;
+  packageId: string;
+  merkleRoot: string;
+  choices: Record<string, VoteChoice>;
+}
+
+export default function HydraBudgetVote() {
+  const { appWallet } = useAppWallet();
+  const { multisigWallet } = useMultisigWallet();
+  const { wallet, connected } = useWallet();
+  const userAddress = useUserStore((s) => s.userAddress);
+  const { toast } = useToast();
+  const ctx = api.useUtils();
+
+  const [choices, setChoices] = useState<Record<string, VoteChoice>>({});
+  const [busy, setBusy] = useState(false);
+
+  const ballotId = BUDGET_2026_BALLOT_ID;
+
+  const {
+    data: ballot,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["ekklesia-ballot", ballotId],
+    queryFn: () => fetchBallot(ballotId),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const questions = ballot?.hydra?.ballot?.questions ?? [];
+  const dRepId = multisigWallet?.getDRepId();
+  // DRep native script for the draft body (role-3 keys, payment-script fallback).
+  const nativeScript = useMemo(
+    () => multisigWallet?.buildScript(3) ?? multisigWallet?.buildScript(0),
+    [multisigWallet],
+  );
+
+  // Existing in-flight Ekklesia packages awaiting co-signers, for this wallet.
+  const { data: pendingSignables } = api.signable.getPendingSignables.useQuery(
+    { walletId: appWallet?.id ?? "" },
+    { enabled: !!appWallet?.id },
+  );
+  const ekklesiaSignables = (pendingSignables ?? []).filter(
+    (s) => s.method === EKKLESIA_METHOD,
+  );
+
+  const { mutateAsync: createSignable } =
+    api.signable.createSignable.useMutation();
+  const { mutateAsync: updateSignable } =
+    api.signable.updateSignable.useMutation();
+
+  /**
+   * Sign a server-provided hex payload with the connected wallet (CIP-8).
+   * NOTE: signs with the user's address (payment credential). For wallets whose
+   * DRep script is built from dedicated role-3 keys, the DRep key must sign via
+   * CIP-95 — wire that here once verified against a live multisig DRep.
+   */
+  const signDataHex = useCallback(
+    async (dataHex: string): Promise<EkklesiaWitness> => {
+      if (!connected) throw new Error("Wallet not connected");
+      if (!userAddress) throw new Error("User address not found");
+      const sig = await wallet.signData(dataHex, userAddress);
+      return { signature: sig.signature, key: sig.key };
+    },
+    [connected, userAddress, wallet],
+  );
+
+  const thresholdReached = useCallback(
+    (signedCount: number) => {
+      if (!appWallet) return false;
+      if (appWallet.type === "atLeast")
+        return signedCount >= (appWallet.numRequiredSigners ?? 1);
+      if (appWallet.type === "all")
+        return signedCount >= appWallet.signersAddresses.length;
+      return signedCount >= 1; // "any"
+    },
+    [appWallet],
+  );
+
+  const handleCreatePackage = useCallback(async () => {
+    if (!appWallet || !dRepId || !nativeScript || !userAddress) return;
+    const items = buildVoteItems(questions, choices);
+    if (items.length === 0) {
+      toast({
+        title: "No selections",
+        description: "Pick Yes / No / Abstain on at least one proposal.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setBusy(true);
+    try {
+      const token = await authenticate({
+        signerAddress: dRepId,
+        signType: "drep",
+        signDataHex,
+      });
+      const { packageId, merkleRoot } = await createVotePackage({
+        ballotId,
+        votes: items,
+        nativeScript,
+        signDataHex,
+        token,
+      });
+
+      const payload: EkklesiaSignablePayload = {
+        kind: EKKLESIA_METHOD,
+        ballotId,
+        packageId,
+        merkleRoot,
+        choices,
+      };
+      const signedCount = 1;
+      await createSignable({
+        walletId: appWallet.id,
+        payload: JSON.stringify(payload),
+        signatures: [],
+        signedAddresses: [userAddress],
+        method: EKKLESIA_METHOD,
+        state: thresholdReached(signedCount) ? 1 : 0,
+        description: `Hydra Budget Vote — ${items.length} proposal(s)`,
+      });
+      await ctx.signable.getPendingSignables.invalidate();
+      toast({
+        title: "Vote package created",
+        description: thresholdReached(signedCount)
+          ? "Threshold met — Ekklesia will aggregate and submit to Hydra."
+          : "Your signature was submitted. Other signers must co-sign.",
+        duration: 8000,
+      });
+    } catch (e) {
+      toast({
+        title: "Could not create vote package",
+        description: e instanceof Error ? e.message : String(e),
+        variant: "destructive",
+        duration: 10000,
+      });
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    appWallet,
+    dRepId,
+    nativeScript,
+    userAddress,
+    questions,
+    choices,
+    signDataHex,
+    ballotId,
+    createSignable,
+    ctx,
+    thresholdReached,
+    toast,
+  ]);
+
+  const handleCoSign = useCallback(
+    async (signable: (typeof ekklesiaSignables)[number]) => {
+      if (!appWallet || !dRepId || !userAddress) return;
+      let payload: EkklesiaSignablePayload;
+      try {
+        payload = JSON.parse(signable.payload) as EkklesiaSignablePayload;
+      } catch {
+        toast({ title: "Invalid package payload", variant: "destructive" });
+        return;
+      }
+      setBusy(true);
+      try {
+        const token = await authenticate({
+          signerAddress: dRepId,
+          signType: "drep",
+          signDataHex,
+        });
+        await coSignVotePackage({
+          ballotId: payload.ballotId,
+          packageId: payload.packageId,
+          merkleRoot: payload.merkleRoot,
+          signDataHex,
+          token,
+        });
+
+        const signedAddresses = [...signable.signedAddresses, userAddress];
+        await updateSignable({
+          signableId: signable.id,
+          signedAddresses,
+          rejectedAddresses: signable.rejectedAddresses,
+          signatures: signable.signatures,
+          state: thresholdReached(signedAddresses.length) ? 1 : 0,
+        });
+        await ctx.signable.getPendingSignables.invalidate();
+        toast({
+          title: "Co-signature submitted",
+          description: thresholdReached(signedAddresses.length)
+            ? "Threshold met — Ekklesia will aggregate and submit to Hydra."
+            : "Thanks — more signatures still needed.",
+          duration: 8000,
+        });
+      } catch (e) {
+        toast({
+          title: "Could not co-sign",
+          description: e instanceof Error ? e.message : String(e),
+          variant: "destructive",
+          duration: 10000,
+        });
+      } finally {
+        setBusy(false);
+      }
+    },
+    [
+      appWallet,
+      dRepId,
+      userAddress,
+      signDataHex,
+      updateSignable,
+      ctx,
+      thresholdReached,
+      toast,
+    ],
+  );
+
+  if (!appWallet) return null;
+
+  if (!dRepId) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Hydra Budget Vote</CardTitle>
+          <CardDescription>
+            Register this wallet as a DRep first to participate in the off-chain
+            Hydra budget vote.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          Hydra Budget Vote{" "}
+          <span className="rounded bg-muted px-2 py-0.5 text-xs font-normal text-muted-foreground">
+            off-chain · Ekklesia
+          </span>
+        </CardTitle>
+        <CardDescription>
+          {ballot ? (
+            <>
+              {ballot.title} — voting closes{" "}
+              {new Date(ballot.votePeriodEnd).toLocaleString()} ·{" "}
+              {questions.length} proposals
+            </>
+          ) : (
+            "Cardano Budget Process 2026"
+          )}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4 text-sm">
+        <div className="flex items-start gap-2 rounded-md border border-yellow-200 bg-yellow-50 p-3 dark:border-yellow-800 dark:bg-yellow-950/20">
+          <Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-yellow-600 dark:text-yellow-400" />
+          <p className="text-xs text-yellow-800 dark:text-yellow-200">
+            This is an off-chain DRep vote tallied in a Hydra head (not an
+            on-chain governance action). Each signer co-signs the same vote
+            package; Ekklesia aggregates once the multisig threshold is met. Vote
+            results are also viewable on{" "}
+            <a
+              href={EKKLESIA_UI}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-0.5 underline"
+            >
+              intersect.ekklesia.vote <ExternalLink className="h-3 w-3" />
+            </a>
+            .
+          </p>
+        </div>
+
+        {isLoading && (
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Loader className="h-4 w-4 animate-spin" /> Loading ballot…
+          </div>
+        )}
+        {error && (
+          <p className="text-red-500">
+            Failed to load ballot: {String((error as Error).message)}
+          </p>
+        )}
+
+        {ekklesiaSignables.length > 0 && (
+          <div className="space-y-2">
+            <div className="font-semibold">Packages awaiting your signature</div>
+            {ekklesiaSignables.map((s) => {
+              const alreadySigned =
+                !!userAddress && s.signedAddresses.includes(userAddress);
+              return (
+                <div
+                  key={s.id}
+                  className="flex items-center justify-between rounded-md border p-2"
+                >
+                  <span className="text-muted-foreground">
+                    {s.description} · {s.signedAddresses.length} signed
+                  </span>
+                  {alreadySigned ? (
+                    <span className="flex items-center gap-1 text-green-500">
+                      <Check className="h-4 w-4" /> Signed
+                    </span>
+                  ) : (
+                    <Button
+                      size="sm"
+                      disabled={busy}
+                      onClick={() => handleCoSign(s)}
+                    >
+                      {busy ? (
+                        <Loader className="h-4 w-4 animate-spin" />
+                      ) : (
+                        "Co-sign"
+                      )}
+                    </Button>
+                  )}
+                </div>
+              );
+            })}
+            <Separator className="my-2" />
+          </div>
+        )}
+
+        {questions.length > 0 && (
+          <div className="max-h-[28rem] space-y-2 overflow-auto pr-1">
+            {questions.map((q) => (
+              <div
+                key={q.questionId}
+                className="flex items-start justify-between gap-3 rounded-md border p-2"
+              >
+                <div className="min-w-0">
+                  <div className="truncate font-medium">{q.question}</div>
+                </div>
+                <Select
+                  value={choices[q.questionId] ?? ""}
+                  onValueChange={(v) =>
+                    setChoices((prev) => ({
+                      ...prev,
+                      [q.questionId]: v as VoteChoice,
+                    }))
+                  }
+                >
+                  <SelectTrigger className="w-32 flex-shrink-0">
+                    <SelectValue placeholder="—" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Yes">Yes</SelectItem>
+                    <SelectItem value="No">No</SelectItem>
+                    <SelectItem value="Abstain">Abstain</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <CardFooter className="justify-end gap-2">
+        <Button
+          onClick={handleCreatePackage}
+          disabled={busy || isLoading || questions.length === 0}
+        >
+          {busy ? (
+            <Loader className="h-4 w-4 animate-spin" />
+          ) : (
+            "Sign & create vote package"
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/pages/wallet/governance/index.tsx
+++ b/src/components/pages/wallet/governance/index.tsx
@@ -12,7 +12,9 @@ import { useBallot } from "@/hooks/useBallot";
 import BallotModal from "./ballot/BallotModal";
 import { BallotModalProvider, useBallotModal } from "@/hooks/useBallotModal";
 import { Button } from "@/components/ui/button";
-import { Vote } from "lucide-react";
+import { Vote, Waves, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/router";
 
 function PageGovernanceContent() {
   const { appWallet } = useAppWallet();
@@ -21,6 +23,8 @@ function PageGovernanceContent() {
   const [manualSelected, setManualSelected] = useState(false);
   const [selectedBallotId, setSelectedBallotId] = useState<string | undefined>(undefined);
   const { isOpen, closeModal, openModal, currentProposalId, currentProposalTitle } = useBallotModal();
+  const router = useRouter();
+  const walletId = router.query.wallet as string;
 
   const { ballots } = useBallot(appWallet?.id);
   const selected = ballots?.find((b) => b.id === selectedBallotId);
@@ -46,6 +50,25 @@ function PageGovernanceContent() {
           onSelectBallot={setSelectedBallotId}
         />
         
+        {/* Off-chain Hydra budget vote entry */}
+        <Link
+          href={`/wallets/${walletId}/governance/hydra`}
+          className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-[#0A0A0B] dark:hover:bg-gray-900"
+        >
+          <div className="flex items-center gap-3">
+            <span className="grid h-9 w-9 place-items-center rounded-full bg-blue-600 text-white">
+              <Waves className="h-4 w-4" />
+            </span>
+            <div>
+              <div className="font-semibold">Hydra Budget Vote</div>
+              <div className="text-sm text-muted-foreground">
+                Off-chain DRep vote on the Cardano Budget 2026 (Ekklesia / Hydra)
+              </div>
+            </div>
+          </div>
+          <ChevronRight className="h-5 w-5 text-muted-foreground" />
+        </Link>
+
         {/* Vote and Clarity cards */}
         <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
           <VoteCard appWallet={appWallet} utxos={manualUtxos} selectedBallotId={selectedBallotId} />

--- a/src/env.js
+++ b/src/env.js
@@ -18,6 +18,16 @@ export const env = createEnv({
     BLOCKFROST_API_KEY_PREPROD: z.string().optional(),
     BLOCKFROST_API_KEY_MAINNET: z.string().optional(),
     /**
+     * Base URL for the Ekklesia / Intersect Hydra voting API that the
+     * `/api/ekklesia/*` proxy forwards to. Defaults to the Intersect mainnet
+     * instance. Browser-direct calls are blocked by CORS, so all Ekklesia
+     * traffic must go through the server proxy.
+     */
+    EKKLESIA_API_BASE: z
+      .string()
+      .url()
+      .default("https://intersect.ekklesia.vote/api"),
+    /**
      * Comma-separated list of hostnames the OG metadata fetcher (`/api/v1/og`)
      * is allowed to talk to. Defaults to a small allow-list when unset; set to
      * "*" to allow any public hostname (still SSRF-guarded against private ranges).
@@ -82,6 +92,7 @@ export const env = createEnv({
     JWT_SECRET: process.env.JWT_SECRET,
     BLOCKFROST_API_KEY_PREPROD: process.env.BLOCKFROST_API_KEY_PREPROD,
     BLOCKFROST_API_KEY_MAINNET: process.env.BLOCKFROST_API_KEY_MAINNET,
+    EKKLESIA_API_BASE: process.env.EKKLESIA_API_BASE,
     OG_ALLOWED_HOSTS: process.env.OG_ALLOWED_HOSTS,
   },
   /**

--- a/src/lib/ekklesia/SPEC.md
+++ b/src/lib/ekklesia/SPEC.md
@@ -1,0 +1,88 @@
+# Ekklesia / Intersect Hydra Voting — reverse-engineered API spec
+
+Source: live API at `https://intersect.ekklesia.vote/api` + the SvelteKit frontend bundle
+(`/_app/immutable/...`). The published docs at `docs.ekklesia.vote` are JS-rendered and
+could not be fetched as text; this spec was confirmed against real responses and the
+shipped client code (June 2026). API stability is not guaranteed across instances — pin and
+re-verify before relying on it.
+
+Base URL: `https://intersect.ekklesia.vote/api`  (versioned calls use the `/v1` prefix → `/api/v1/...`)
+
+Transport: all requests send `Content-Type: application/json`, `credentials: include`
+(cookie), and `Authorization: Bearer <jwt>` when a token is held. A `401` means the token
+expired → re-auth.
+
+## The 2026 Budget ballot
+
+- `GET /api/v1/ballots` → list. The budget ballot id is **`6a1512d782978c99456fe6de`**
+  (`source: "hydra"`, `voterType: "drep"`, `voteWeighted: true`,
+  window `2026-05-26 → 2026-06-12T12:00:00Z`).
+- `GET /api/v1/ballots/:id` → full ballot. The votable content is under
+  `data.hydra.ballot`:
+  - `questions[]` (69 proposals): each `{ questionId, question (title), description,
+    method: "binary", options: [{label:"Yes",value:1},{label:"No",value:2}],
+    minSelections, maxSelections, requireAnswer, contentHash }`.
+  - `ekklesia`: `{ namespace, votingAuthority, context: "hydra-head",
+    acceptedCredentials: ["drep"], merkleRoot (ballot-definition root),
+    votingWindow:{open,close} }`.
+
+## Auth flow (per signer) — CIP-8 → JWT
+
+1. `POST /api/v1/session` `{ signerAddress, signType }` (signType `"drep"` for us) → returns
+   a challenge containing `dataHex` (the nonce to sign) plus identity echoes
+   (`userId`, `userIdHex` for drep, `signerAddressHex`, `merkleRoot`).
+2. Sign `dataHex` with CIP-8: `(api.cip95 ?? api).signData(address, dataHex)` →
+   Mesh `DataSignature` `{ signature, key }` (COSE_Sign1 hex + COSE_Key hex).
+3. `PUT /api/v1/session` `{ signerAddress, signType, signature, key }` → sets JWT
+   (cookie + bearer).
+- `GET /api/v1/session/` → current voter; `DELETE /api/v1/session` → logout.
+
+## Vote flow
+
+`merkleRoot → hex` helper used before signing (sign the merkleRoot **string** as its ASCII bytes):
+```js
+const toDataHex = (s) => { let h=""; for (let i=0;i<s.length;i++) h+=s.charCodeAt(i).toString(16).padStart(2,"0"); return h; };
+```
+
+Vote item shape (per question):
+```js
+// Yes → selection [1], No → selection [2]; abstain → {abstain:true}
+{ questionId, selection: [1] }   |   { questionId, abstain: true }
+```
+
+1. **Draft** `POST /api/v1/votes/:ballotId/draft`
+   body: `{ votes: VoteItem[], nativeScript?: <script>, calidusDeclaration?: {...} }`
+   - **Multisig DRep**: include `nativeScript` (the DRep native script) so the server can
+     parse the required-signer set / threshold (`sig`/`all`/`any`/`atLeast`).
+   - Response `d`: `{ merkleRoot, multisig, nonce, status, id|_id, package:{id|_id,...} }`.
+     `packageId = d.package.id ?? d.package._id ?? d.id`.
+2. **Sign** `dataHex = toDataHex(d.merkleRoot)`; `(api.cip95 ?? api).signData(drepAddress, dataHex)`
+   → `{ signature, key }`.
+3. **Submit signature** `POST /api/v1/votes/:ballotId/signature`
+   body: `{ packageId, witness: { signature, key } }`  (server also accepts
+   `{ COSE_Sign1_hex, COSE_Key_hex }`). Each multisig cosigner calls this with the **same**
+   `packageId` (one shared draft / merkleRoot — do NOT redraft per signer; each draft has its
+   own nonce → different merkleRoot → non-aggregatable).
+4. **Submit package** `POST /api/v1/votes/:ballotId/submit` `{ packageId }` once the native
+   script threshold of witnesses is met (single-sig may auto-submit after the signature step;
+   multisig submits/aggregates when complete). The broker pushes to the Hydra head.
+
+## Read / manage
+
+- `GET /api/v1/votes/:ballotId/mine` → my current votes.
+- `GET /api/v1/votes/:ballotId/packages?includeTerminal&limit` → my draft/vote packages
+  (status incl. `awaiting-signatures`).
+- `DELETE /api/v1/votes/:ballotId/package/:packageId` → cancel a draft, release its nonce.
+
+## Mapping to this app
+
+- `signData` `{signature,key}` == Mesh `DataSignature` returned by `sign()` in
+  `src/utils/signing.ts` (role 3 = DRep). Use it verbatim as both the auth signature and the
+  vote witness.
+- DRep address/credential: `multisigWallet.getDRepId()` (CIP-129) / `getDRepId105()`;
+  native script for the draft: `multisigWallet.getDRepScript()` /
+  `getNativeScript()`-equivalent.
+- Multi-signer coordination maps onto the existing **signable** subsystem
+  (`src/server/api/routers/signable.ts`): store `{ ballotId, packageId, merkleRoot, votes }`
+  as the signable payload; each signer appends their `{signature,key}` and POSTs it to
+  `/signature`; complete at threshold.

--- a/src/lib/ekklesia/client.ts
+++ b/src/lib/ekklesia/client.ts
@@ -1,0 +1,182 @@
+/**
+ * Thin client for the Ekklesia / Intersect Hydra voting API, routed through the
+ * server proxy at `/api/ekklesia/*` (CORS blocks browser-direct calls).
+ *
+ * Auth lives under `/v0`, ballots & votes under `/v1`.
+ * See src/lib/ekklesia/SPEC.md for the full reverse-engineered spec.
+ */
+import type {
+  EkklesiaBallot,
+  EkklesiaDraftRequest,
+  EkklesiaDraftResponse,
+  EkklesiaPackage,
+  EkklesiaSessionChallenge,
+  EkklesiaSignType,
+  EkklesiaWitness,
+} from "./types";
+
+const PROXY_BASE = "/api/ekklesia";
+
+/**
+ * Encode the merkleRoot string as the hex of its ASCII bytes — this is the
+ * `dataHex` passed to `signData` (sign the merkleRoot *string*, not its bytes).
+ * Mirrors Ekklesia's own `toDataHex` helper.
+ */
+export function merkleRootToDataHex(merkleRoot: string): string {
+  if (typeof merkleRoot !== "string") {
+    throw new Error("merkleRoot must be a string");
+  }
+  let hex = "";
+  for (let i = 0; i < merkleRoot.length; i++) {
+    hex += merkleRoot.charCodeAt(i).toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+/** Resolve a packageId from a draft response or package object. */
+export function getPackageId(
+  pkg: Pick<EkklesiaDraftResponse, "id" | "_id" | "package">,
+): string | undefined {
+  return pkg.package?.id ?? pkg.package?._id ?? pkg.id ?? pkg._id;
+}
+
+async function call<T>(
+  path: string,
+  init: RequestInit & { token?: string } = {},
+): Promise<T> {
+  const { token, headers, ...rest } = init;
+  const h = new Headers(headers);
+  h.set("Content-Type", "application/json");
+  if (token) h.set("Authorization", `Bearer ${token}`);
+
+  const res = await fetch(`${PROXY_BASE}${path}`, {
+    ...rest,
+    headers: h,
+    credentials: "include",
+  });
+
+  const text = await res.text();
+  let body: unknown = undefined;
+  try {
+    body = text ? JSON.parse(text) : undefined;
+  } catch {
+    body = text;
+  }
+  if (!res.ok) {
+    const message =
+      (body as { message?: string; error?: string })?.message ??
+      (body as { error?: string })?.error ??
+      `Ekklesia request failed (${res.status})`;
+    throw new Error(message);
+  }
+  return body as T;
+}
+
+/* ----------------------------- Ballots / read ----------------------------- */
+
+export async function fetchBallot(ballotId: string): Promise<EkklesiaBallot> {
+  const res = await call<{ data: EkklesiaBallot }>(`/v1/ballots/${ballotId}`);
+  return res.data;
+}
+
+export async function fetchMyVotes(
+  ballotId: string,
+  token?: string,
+): Promise<unknown> {
+  return call(`/v1/votes/${ballotId}/mine`, { token });
+}
+
+export async function fetchPackages(
+  ballotId: string,
+  token?: string,
+  opts: { includeTerminal?: boolean; limit?: number } = {},
+): Promise<EkklesiaPackage[]> {
+  const qs = new URLSearchParams();
+  if (opts.includeTerminal) qs.set("includeTerminal", "true");
+  if (opts.limit) qs.set("limit", String(opts.limit));
+  const suffix = qs.toString() ? `?${qs}` : "";
+  const res = await call<{ data?: EkklesiaPackage[] }>(
+    `/v1/votes/${ballotId}/packages${suffix}`,
+    { token },
+  );
+  return res.data ?? [];
+}
+
+/* --------------------------------- Auth ---------------------------------- */
+
+/** Step 1: request a nonce challenge to sign. */
+export async function requestSession(
+  signerAddress: string,
+  signType: EkklesiaSignType,
+): Promise<EkklesiaSessionChallenge> {
+  return call<EkklesiaSessionChallenge>(`/v0/session`, {
+    method: "POST",
+    body: JSON.stringify({ signerAddress, signType }),
+  });
+}
+
+/** Step 2: submit the signed nonce; returns the session (JWT via cookie/body). */
+export async function submitSession(
+  signerAddress: string,
+  signType: EkklesiaSignType,
+  witness: EkklesiaWitness,
+): Promise<{ token?: string; [key: string]: unknown }> {
+  return call(`/v0/session`, {
+    method: "PUT",
+    body: JSON.stringify({ signerAddress, signType, ...witness }),
+  });
+}
+
+/* --------------------------------- Vote ---------------------------------- */
+
+/** Create a vote draft/package. Returns the shared `merkleRoot` + packageId. */
+export async function draftVote(
+  ballotId: string,
+  body: EkklesiaDraftRequest,
+  token?: string,
+): Promise<EkklesiaDraftResponse> {
+  return call<EkklesiaDraftResponse>(`/v1/votes/${ballotId}/draft`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    token,
+  });
+}
+
+/** Attach a signer's witness to an existing package (one per cosigner). */
+export async function submitSignature(
+  ballotId: string,
+  packageId: string,
+  witness: EkklesiaWitness,
+  token?: string,
+): Promise<{ status?: string; error?: string; [key: string]: unknown }> {
+  return call(`/v1/votes/${ballotId}/signature`, {
+    method: "POST",
+    body: JSON.stringify({ packageId, witness }),
+    token,
+  });
+}
+
+/** Submit/finalize a package once the script threshold of witnesses is met. */
+export async function submitPackage(
+  ballotId: string,
+  packageId: string,
+  token?: string,
+): Promise<{ status?: string; error?: string; [key: string]: unknown }> {
+  return call(`/v1/votes/${ballotId}/submit`, {
+    method: "POST",
+    body: JSON.stringify({ packageId }),
+    token,
+  });
+}
+
+/** Cancel a draft package and release its nonce. */
+export async function cancelPackage(
+  ballotId: string,
+  packageId: string,
+  token?: string,
+): Promise<unknown> {
+  return call(`/v1/votes/${ballotId}/package/${packageId}`, {
+    method: "DELETE",
+    token,
+  });
+}

--- a/src/lib/ekklesia/types.ts
+++ b/src/lib/ekklesia/types.ts
@@ -1,0 +1,130 @@
+/**
+ * Types for the Ekklesia / Intersect Hydra voting API.
+ * See src/lib/ekklesia/SPEC.md for the full reverse-engineered spec.
+ */
+import type { NativeScript } from "@meshsdk/core";
+
+/** The Intersect 2026 budget ballot id (source: "hydra"). */
+export const BUDGET_2026_BALLOT_ID = "6a1512d782978c99456fe6de";
+
+/** Credential type a voter authenticates / votes as. We only use "drep". */
+export type EkklesiaSignType = "drep" | "stake" | "pool" | "address";
+
+/** A single option for a binary/multi question (e.g. Yes=1, No=2). */
+export interface EkklesiaQuestionOption {
+  label: string;
+  value: number;
+}
+
+/** One proposal/question within a Hydra ballot. */
+export interface EkklesiaQuestion {
+  questionId: string;
+  question: string;
+  description: string;
+  method: string; // "binary" for budget proposals
+  options: EkklesiaQuestionOption[];
+  minSelections: number;
+  maxSelections: number;
+  requireAnswer: boolean;
+  contentHash: string;
+}
+
+/** The on-Hydra ballot definition embedded in a ballot's `hydra.ballot`. */
+export interface EkklesiaHydraBallot {
+  title: string;
+  description: string;
+  specVersion: string;
+  endEpoch: number;
+  questions: EkklesiaQuestion[];
+  ekklesia: {
+    namespace: string;
+    votingAuthority: string;
+    context: string;
+    acceptedCredentials: string[];
+    merkleRoot: string;
+    votingWindow: { open: string; close: string };
+  };
+}
+
+/** A ballot as returned by `GET /v1/ballots/:id`. */
+export interface EkklesiaBallot {
+  id: string;
+  source: string;
+  title: string;
+  description: string;
+  status: string;
+  voterType: string;
+  voteWeighted: boolean;
+  votePeriodStart: string;
+  votePeriodEnd: string;
+  hydra: {
+    headStatus: string;
+    ballotCid: string;
+    instancePolicyId: string;
+    ballot: EkklesiaHydraBallot;
+  };
+}
+
+/** A single vote selection sent in a draft body. */
+export type EkklesiaVoteItem =
+  | { questionId: string; selection: number[] }
+  | { questionId: string; abstain: true };
+
+/** Request body for `POST /v1/votes/:ballotId/draft`. */
+export interface EkklesiaDraftRequest {
+  votes: EkklesiaVoteItem[];
+  /** Required for multisig DReps: the DRep native script (so the server can
+   * parse the required-signer set / threshold). */
+  nativeScript?: NativeScript;
+}
+
+/** Response from `POST /v1/votes/:ballotId/draft`. */
+export interface EkklesiaDraftResponse {
+  merkleRoot: string;
+  nonce?: string;
+  status?: string;
+  multisig?: EkklesiaMultisigState | null;
+  id?: string;
+  _id?: string;
+  package?: { id?: string; _id?: string; status?: string };
+  error?: string;
+}
+
+/** Multisig progress info attached to a draft/package. */
+export interface EkklesiaMultisigState {
+  required?: number;
+  collected?: number;
+  signers?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * A vote witness. Mesh's `DataSignature` (`{ signature, key }`) is accepted
+ * directly; the server also accepts `{ COSE_Sign1_hex, COSE_Key_hex }`.
+ */
+export interface EkklesiaWitness {
+  signature: string;
+  key: string;
+}
+
+/** A vote "package" as returned by `GET /v1/votes/:ballotId/packages`. */
+export interface EkklesiaPackage {
+  id?: string;
+  _id?: string;
+  status: string; // e.g. "awaiting-signatures", "submitted"
+  merkleRoot?: string;
+  nonce?: string;
+  multisig?: EkklesiaMultisigState | null;
+  votes?: unknown;
+}
+
+/** Auth challenge from `POST /v1/session`. */
+export interface EkklesiaSessionChallenge {
+  /** The nonce to sign with CIP-8 (hex). */
+  dataHex: string;
+  userId?: string;
+  userIdHex?: string;
+  signerAddressHex?: string;
+  merkleRoot?: string;
+  error?: string;
+}

--- a/src/lib/ekklesia/voteFlow.ts
+++ b/src/lib/ekklesia/voteFlow.ts
@@ -1,0 +1,124 @@
+/**
+ * Orchestration for casting a multisig-DRep vote on an Ekklesia / Hydra ballot.
+ *
+ * Framework-agnostic: the React layer supplies a `signDataHex` callback (which
+ * wraps the connected wallet's CIP-8/CIP-95 `signData`) and persists the shared
+ * package via the existing `signable` tRPC router. See SPEC.md.
+ *
+ * Multisig model: ONE shared draft → one `merkleRoot` / `packageId`; every
+ * cosigner signs that same merkleRoot and posts their witness separately. Do not
+ * redraft per signer (each draft gets a fresh nonce → a different merkleRoot →
+ * witnesses cannot aggregate).
+ */
+import type { NativeScript } from "@meshsdk/core";
+import {
+  draftVote,
+  merkleRootToDataHex,
+  getPackageId,
+  requestSession,
+  submitSession,
+  submitSignature,
+} from "./client";
+import type {
+  EkklesiaQuestion,
+  EkklesiaSignType,
+  EkklesiaVoteItem,
+  EkklesiaWitness,
+} from "./types";
+
+export type VoteChoice = "Yes" | "No" | "Abstain";
+
+/** Callback that signs a hex payload with the connected wallet (returns COSE). */
+export type SignDataHex = (dataHex: string) => Promise<EkklesiaWitness>;
+
+/**
+ * Map a {questionId -> choice} selection into Ekklesia vote items, resolving
+ * "Yes"/"No" to the question's option `value` (Yes/No are by-label).
+ */
+export function buildVoteItems(
+  questions: EkklesiaQuestion[],
+  choices: Record<string, VoteChoice>,
+): EkklesiaVoteItem[] {
+  const items: EkklesiaVoteItem[] = [];
+  for (const q of questions) {
+    const choice = choices[q.questionId];
+    if (!choice) continue; // unanswered questions are omitted
+    if (choice === "Abstain") {
+      items.push({ questionId: q.questionId, abstain: true });
+      continue;
+    }
+    const option = q.options.find(
+      (o) => o.label.toLowerCase() === choice.toLowerCase(),
+    );
+    if (!option) {
+      throw new Error(
+        `Question ${q.questionId} has no "${choice}" option`,
+      );
+    }
+    items.push({ questionId: q.questionId, selection: [option.value] });
+  }
+  return items;
+}
+
+/**
+ * Authenticate one signer with Ekklesia: request a nonce, sign it, exchange for
+ * a session. Returns the bearer token (also set as a cookie by the proxy).
+ */
+export async function authenticate(params: {
+  signerAddress: string;
+  signType: EkklesiaSignType;
+  signDataHex: SignDataHex;
+}): Promise<string | undefined> {
+  const { signerAddress, signType, signDataHex } = params;
+  const challenge = await requestSession(signerAddress, signType);
+  if (challenge.error) throw new Error(challenge.error);
+  if (!challenge.dataHex) {
+    throw new Error("Ekklesia session: no challenge returned");
+  }
+  const witness = await signDataHex(challenge.dataHex);
+  const session = await submitSession(signerAddress, signType, witness);
+  return session.token;
+}
+
+/**
+ * Initiator path: create the shared draft (with the DRep native script) and
+ * attach the initiator's witness. Returns the package coordinates that
+ * cosigners need (persist these in a `signable` record, method "ekklesia-vote").
+ */
+export async function createVotePackage(params: {
+  ballotId: string;
+  votes: EkklesiaVoteItem[];
+  nativeScript: NativeScript;
+  signDataHex: SignDataHex;
+  token?: string;
+}): Promise<{ packageId: string; merkleRoot: string; witness: EkklesiaWitness }> {
+  const { ballotId, votes, nativeScript, signDataHex, token } = params;
+  const draft = await draftVote(ballotId, { votes, nativeScript }, token);
+  if (draft.error) throw new Error(draft.error);
+  const packageId = getPackageId(draft);
+  if (!packageId || !draft.merkleRoot) {
+    throw new Error("Ekklesia draft: missing packageId or merkleRoot");
+  }
+  const witness = await signDataHex(merkleRootToDataHex(draft.merkleRoot));
+  const res = await submitSignature(ballotId, packageId, witness, token);
+  if (res.error) throw new Error(res.error);
+  return { packageId, merkleRoot: draft.merkleRoot, witness };
+}
+
+/**
+ * Cosigner path: sign the already-created shared merkleRoot and submit the
+ * witness against the same package.
+ */
+export async function coSignVotePackage(params: {
+  ballotId: string;
+  packageId: string;
+  merkleRoot: string;
+  signDataHex: SignDataHex;
+  token?: string;
+}): Promise<EkklesiaWitness> {
+  const { ballotId, packageId, merkleRoot, signDataHex, token } = params;
+  const witness = await signDataHex(merkleRootToDataHex(merkleRoot));
+  const res = await submitSignature(ballotId, packageId, witness, token);
+  if (res.error) throw new Error(res.error);
+  return witness;
+}

--- a/src/pages/api/ekklesia/[...path].ts
+++ b/src/pages/api/ekklesia/[...path].ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { env } from "@/env";
+
+/**
+ * Transparent proxy to the Ekklesia / Intersect Hydra voting API.
+ *
+ * Ekklesia's CORS only allows its own origin, so the browser cannot call it
+ * directly. This route forwards `/api/ekklesia/<path>` → `${EKKLESIA_API_BASE}/<path>`,
+ * passing the request body, the `Authorization: Bearer` header, and cookies in
+ * both directions (Ekklesia issues a JWT as a cookie on `PUT /session`).
+ *
+ * See src/lib/ekklesia/SPEC.md for the reverse-engineered API.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const segments = req.query.path;
+  const path = Array.isArray(segments) ? segments.join("/") : (segments ?? "");
+
+  // Preserve the original query string (minus the catch-all `path` param).
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(req.query)) {
+    if (key === "path") continue;
+    if (Array.isArray(value)) value.forEach((v) => search.append(key, v));
+    else if (value !== undefined) search.append(key, value);
+  }
+  const qs = search.toString();
+  const url = `${env.EKKLESIA_API_BASE}/${path}${qs ? `?${qs}` : ""}`;
+
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (typeof req.headers.authorization === "string") {
+    headers.Authorization = req.headers.authorization;
+  }
+  if (typeof req.headers.cookie === "string") {
+    headers.Cookie = req.headers.cookie;
+  }
+
+  const hasBody = req.method !== "GET" && req.method !== "HEAD";
+
+  try {
+    const upstream = await fetch(url, {
+      method: req.method,
+      headers,
+      body: hasBody ? JSON.stringify(req.body ?? {}) : undefined,
+    });
+
+    // Pass through any Set-Cookie (the session JWT) to the browser.
+    const setCookie = upstream.headers.getSetCookie?.() ?? [];
+    if (setCookie.length > 0) res.setHeader("Set-Cookie", setCookie);
+
+    const text = await upstream.text();
+    res.status(upstream.status);
+    const contentType = upstream.headers.get("content-type");
+    if (contentType) res.setHeader("Content-Type", contentType);
+    res.send(text);
+  } catch (error) {
+    console.error("Ekklesia proxy error:", error);
+    res.status(502).json({
+      error: "Ekklesia proxy failed",
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/src/pages/wallets/[wallet]/governance/hydra/index.tsx
+++ b/src/pages/wallets/[wallet]/governance/hydra/index.tsx
@@ -1,0 +1,11 @@
+import HydraBudgetVote from "@/components/pages/wallet/governance/hydra/HydraBudgetVote";
+
+export const getServerSideProps = () => ({ props: {} });
+
+export default function PageWalletHydraVote() {
+  return (
+    <main className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-4 p-3 sm:p-4 lg:p-8">
+      <HydraBudgetVote />
+    </main>
+  );
+}


### PR DESCRIPTION
## What & why

The Intersect **Cardano Budget 2026** vote (https://hydra-voting.intersectmbo.org) is **not** an on-chain CIP-1694 governance action — it runs on **Ekklesia / Hydra (L2)**, where DReps cast Yes/No per proposal as **off-chain CIP-8 signed messages** tallied in a Hydra head. The existing on-chain "Vote" button can't drive it. Ekklesia supports native-script (multisig) DReps, so this PR adds an in-app flow where each signer co-signs the same vote package and Ekklesia aggregates once the multisig threshold is met.

Ballot `6a1512d782978c99456fe6de` is live and **closes 2026-06-12 12:00 UTC**.

## How the spec was obtained

The published docs (`docs.ekklesia.vote`) are a JS-rendered SPA. The API was reverse-engineered from the **live API + shipped frontend bundle** and confirmed against real responses — documented in [`src/lib/ekklesia/SPEC.md`](src/lib/ekklesia/SPEC.md).

Key wire format:
- Auth: `POST→PUT /api/v0/session` (sign nonce → JWT); votes under `/api/v1`
- Draft: `POST /v1/votes/:id/draft` `{ votes:[{questionId, selection:[1]}|{questionId,abstain:true}], nativeScript }` → `{ merkleRoot, packageId }`
- Witness: sign `merkleRoot` (as ASCII-hex) → `{signature,key}` (== Mesh `DataSignature`) → `POST /v1/votes/:id/signature { packageId, witness }`, one per cosigner
- CORS is locked to Ekklesia's origin → **server proxy required**

## Changes

- `src/pages/api/ekklesia/[...path].ts` — transparent proxy (forwards auth + cookies)
- `src/lib/ekklesia/{types,client,voteFlow}.ts` — typed client + orchestration, reusing the **signable** subsystem for multi-signer coordination
- `src/components/pages/wallet/governance/hydra/HydraBudgetVote.tsx` + page + governance-hub entry
- `EKKLESIA_API_BASE` env var
- `src/lib/ekklesia/SPEC.md` — reverse-engineered API reference

## Verification

- `tsc --noEmit`: 0 new type errors (only pre-existing mesh/prisma ones)
- `next lint`: clean for new files
- `jest` signing suite: 6/6 pass
- Live ballot reachable and open (`drep`, head Open, 69 proposals)

## ⚠️ Needs live-wallet verification before the deadline

Two spots can't be exercised headlessly and are flagged inline:
1. **Per-signer CIP-95 DRep-key signing** — the `signData` callback currently signs with the payment/user address (correct when the DRep script falls back to the payment script); dedicated role-3 DRep-key wallets need CIP-95 DRep-key signing wired in.
2. **Multisig session binding** (`signerAddress` vs `scriptAddress` per cosigner) and whether `/submit` is explicit or broker-automatic.

Recommend an end-to-end test on a 2-of-N wallet with a real DRep; manual voting via Ekklesia's CardanoSigner is the fallback for June 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)