### PR TITLE
fix(auth): normalize hex-encoded CIP-30 addresses to bech32 before use

### DIFF
--- a/src/__tests__/addressCompatibility.test.ts
+++ b/src/__tests__/addressCompatibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from '@jest/globals';
+import { normalizeAddressToBech32 } from '../utils/addressCompatibility';
+
+describe('normalizeAddressToBech32', () => {
+  // 57-byte mainnet base address as returned hex-encoded by some CIP-30
+  // wallets (mobile in-app browsers) from getChangeAddress/getUsedAddresses.
+  const mainnetBaseHex =
+    '01188691447471593ad888086cd3cffcb93833f38225ebd56bb1986476b59d6e7bd1e5ae3ae5ffe52dada5528d868ef67b738687543193df8d';
+  const mainnetBaseBech32 =
+    'addr1qyvgdy2yw3c4jwkc3qyxe570ljunsvlnsgj7h4ttkxvxga44n4h8h5094cawtll99kk6255ds680v7mns6r4gvvnm7xscrhvw9';
+
+  it('converts hex-encoded mainnet base address bytes to bech32', () => {
+    expect(normalizeAddressToBech32(mainnetBaseHex)).toBe(mainnetBaseBech32);
+  });
+
+  it('converts hex-encoded testnet base address bytes to addr_test', () => {
+    const testnetHex = '00' + mainnetBaseHex.slice(2);
+    expect(normalizeAddressToBech32(testnetHex)).toMatch(/^addr_test1/);
+  });
+
+  it('converts hex-encoded reward address bytes to stake bech32', () => {
+    const rewardHex = 'e1ad675b9ef479ae3ae5ffe52dada5528d868ef67b738687543193df8d';
+    expect(normalizeAddressToBech32(rewardHex)).toBe(
+      'stake1uxkkwku773u6uwh9lljjmtd922xcdrhk0decdp65xxfalrgc9mvct',
+    );
+  });
+
+  it('returns bech32 addresses unchanged', () => {
+    expect(normalizeAddressToBech32(mainnetBaseBech32)).toBe(mainnetBaseBech32);
+    const stake = 'stake1uxkkwku773u6uwh9lljjmtd922xcdrhk0decdp65xxfalrgc9mvct';
+    expect(normalizeAddressToBech32(stake)).toBe(stake);
+  });
+
+  it('returns non-address input unchanged', () => {
+    expect(normalizeAddressToBech32('deadbeef')).toBe('deadbeef');
+    expect(normalizeAddressToBech32('not-an-address')).toBe('not-an-address');
+    expect(normalizeAddressToBech32('')).toBe('');
+  });
+});

--- a/src/components/common/cardano-objects/connect-wallet.tsx
+++ b/src/components/common/cardano-objects/connect-wallet.tsx
@@ -16,14 +16,8 @@ import React from "react";
 import useUser from "@/hooks/useUser";
 import { useUserStore } from "@/lib/zustand/user";
 import { getProvider } from "@/utils/get-provider";
-import {
-  Asset,
-  deserializeAddress,
-  pubKeyAddress,
-  scriptAddress,
-  serializeAddressObj,
-  serializeRewardAddress,
-} from "@meshsdk/core";
+import { Asset } from "@meshsdk/core";
+import { normalizeAddressToBech32 } from "@/utils/addressCompatibility";
 import useUTXOS from "@/hooks/useUTXOS";
 import { api } from "@/utils/api";
 import { useWalletContext, WalletState } from "@/hooks/useWalletContext";
@@ -405,23 +399,7 @@ function ConnectWalletContent({
         }
 
         // Normalize possible hex-encoded CIP-30 address bytes to bech32 (addr/addr_test)
-        try {
-          if (!address.startsWith("addr1") && !address.startsWith("addr_test1")) {
-            const d = deserializeAddress(address);
-            const stakeCredential = d.stakeCredentialHash || d.stakeScriptCredentialHash || "";
-            const rebuilt =
-              d.pubKeyHash
-                ? pubKeyAddress(d.pubKeyHash, stakeCredential, !!d.stakeScriptCredentialHash)
-                : d.scriptHash
-                  ? scriptAddress(d.scriptHash, stakeCredential, !!d.stakeScriptCredentialHash)
-                  : null;
-            if (rebuilt) {
-              address = serializeAddressObj(rebuilt, netId);
-            }
-          }
-        } catch {
-          // If normalization fails, keep original (better than dropping the address)
-        }
+        address = normalizeAddressToBech32(address);
 
         setUserAddress(address);
 
@@ -430,24 +408,8 @@ function ConnectWalletContent({
         let stakeAddress = stakeAddresses[0];
 
         // Normalize possible hex-encoded reward address bytes to bech32 (stake/stake_test)
-        try {
-          if (
-            stakeAddress &&
-            !stakeAddress.startsWith("stake1") &&
-            !stakeAddress.startsWith("stake_test1")
-          ) {
-            const d = deserializeAddress(stakeAddress);
-            const stakeHash = d.stakeCredentialHash || d.stakeScriptCredentialHash;
-            if (stakeHash) {
-              stakeAddress = serializeRewardAddress(
-                stakeHash,
-                !!d.stakeScriptCredentialHash,
-                netId,
-              );
-            }
-          }
-        } catch {
-          // ignore
+        if (stakeAddress) {
+          stakeAddress = normalizeAddressToBech32(stakeAddress);
         }
 
         if (!stakeAddress || !address) {
@@ -483,7 +445,7 @@ function ConnectWalletContent({
         utxosInitializedRef.current = false;
       }
     })();
-  }, [isUtxosEnabled, utxosWallet, isUserLoading, createUser, setUserAddress, netId]);
+  }, [isUtxosEnabled, utxosWallet, isUserLoading, createUser, setUserAddress]);
 
   // Handle UTXOS wallet assets and network
   useEffect(() => {

--- a/src/components/common/modals/WalletAuthModal.tsx
+++ b/src/components/common/modals/WalletAuthModal.tsx
@@ -4,8 +4,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import useUTXOS from "@/hooks/useUTXOS";
-import { useSiteStore } from "@/lib/zustand/site";
-import { deserializeAddress, pubKeyAddress, scriptAddress, serializeAddressObj } from "@meshsdk/core";
+import { normalizeAddressToBech32 } from "@/utils/addressCompatibility";
 
 interface WalletAuthModalProps {
   address: string; // display label; actual signing address is derived from wallet.getUsedAddresses()
@@ -17,8 +16,6 @@ interface WalletAuthModalProps {
 
 export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuthorize = false }: WalletAuthModalProps) {
   const { wallet, connected } = useWallet();
-  const network = useSiteStore((state) => state.network);
-  const netId = (network === 1 ? 1 : 0) as 0 | 1;
   const { wallet: utxosWallet, isEnabled: isUtxosEnabled } = useUTXOS();
   const { toast } = useToast();
   const [submitting, setSubmitting] = useState(false);
@@ -28,21 +25,6 @@ export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuth
     isUtxosEnabled && utxosWallet?.cardano
       ? utxosWallet.cardano
       : (wallet && connected ? wallet : null);
-
-  const normalizePaymentAddress = useCallback((maybeHexOrBech: string): string => {
-    if (maybeHexOrBech.startsWith("addr1") || maybeHexOrBech.startsWith("addr_test1")) {
-      return maybeHexOrBech;
-    }
-    const d = deserializeAddress(maybeHexOrBech);
-    const stakeCredential = d.stakeCredentialHash || d.stakeScriptCredentialHash || "";
-    const rebuilt =
-      d.pubKeyHash
-        ? pubKeyAddress(d.pubKeyHash, stakeCredential, !!d.stakeScriptCredentialHash)
-        : d.scriptHash
-          ? scriptAddress(d.scriptHash, stakeCredential, !!d.stakeScriptCredentialHash)
-          : null;
-    return rebuilt ? serializeAddressObj(rebuilt, netId) : maybeHexOrBech;
-  }, [netId]);
 
   const handleAuthorize = useCallback(async () => {
     if (!signingWallet) {
@@ -95,7 +77,10 @@ export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuth
       if (!signingAddress) {
         throw new Error("No addresses found for wallet");
       }
-      signingAddress = normalizePaymentAddress(signingAddress);
+      signingAddress = normalizeAddressToBech32(signingAddress);
+      if (!signingAddress.startsWith("addr1") && !signingAddress.startsWith("addr_test1")) {
+        throw new Error("Could not read a valid payment address from this wallet.");
+      }
 
       // 1) Get nonce from existing endpoint
       const nonceRes = await fetch(`/api/v1/getNonce?address=${encodeURIComponent(signingAddress)}`);
@@ -171,7 +156,7 @@ export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuth
     } finally {
       setSubmitting(false);
     }
-  }, [signingWallet, toast, onAuthorized, onClose, normalizePaymentAddress]);
+  }, [signingWallet, toast, onAuthorized, onClose]);
 
   // Auto-authorize when modal opens if autoAuthorize is true (only once)
   useEffect(() => {

--- a/src/utils/addressCompatibility.ts
+++ b/src/utils/addressCompatibility.ts
@@ -1,4 +1,5 @@
 import { resolvePaymentKeyHash, resolveStakeKeyHash } from "@meshsdk/core";
+import { Address, HexBlob } from "@meshsdk/core-cst";
 
 export type ResolvedKeyHash = {
   keyHash: string;
@@ -25,4 +26,27 @@ export function tryResolveKeyHash(address: string): ResolvedKeyHash | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * CIP-30 wallets (notably mobile in-app browsers) return addresses from
+ * getChangeAddress/getUsedAddresses/getRewardAddresses as hex-encoded CBOR
+ * bytes rather than bech32. Bech32-only parsers such as `deserializeAddress`
+ * throw "Invalid checksum" on that hex, so normalize to bech32 first. The
+ * network id is taken from the address header byte, so no network parameter
+ * is needed. Returns the input unchanged when it is already bech32 or cannot
+ * be parsed as address bytes.
+ */
+export function normalizeAddressToBech32(address: string): string {
+  if (/^(addr|addr_test|stake|stake_test)1/.test(address)) {
+    return address;
+  }
+  if (address.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(address)) {
+    try {
+      return Address.fromBytes(HexBlob(address)).toBech32();
+    } catch {
+      // not address bytes; fall through
+    }
+  }
+  return address;
 }


### PR DESCRIPTION
## Problem

Wallet authorization fails on some mobile wallets (in-app dApp browsers) with a raw bech32 decoder error in the toast:

> Authorization failed
> Invalid checksum in 01188691447471593ad888086cd3cff…: expected "vdmmxx"

These wallets return addresses from the CIP-30 endpoints (`getChangeAddress` / `getUsedAddresses` / `getRewardAddresses`) as hex-encoded CBOR bytes instead of bech32. `WalletAuthModal`'s `normalizePaymentAddress` passed anything not starting with `addr1` into Mesh's `deserializeAddress()`, which only understands bech32 — the decoder threw, and the raw error surfaced to the user, blocking authorization entirely.

`connect-wallet.tsx` had the same `deserializeAddress`-on-hex bug twice (UTXOS payment + stake address normalization), silently swallowed by `try/catch`, so hex addresses flowed into the user store and `createUser`.

## Fix

- New shared helper `normalizeAddressToBech32()` in `src/utils/addressCompatibility.ts` using `Address.fromBytes(…).toBech32()` from `@meshsdk/core-cst`. Handles base, testnet, and reward addresses; the network id comes from the address header byte, so no `netId` guessing. Non-address input passes through unchanged.
- `WalletAuthModal` uses the helper and shows a clear "Could not read a valid payment address from this wallet." message if the address still cannot be parsed, instead of a raw decoder error.
- Both broken normalization blocks in `connect-wallet.tsx` replaced with the helper.

Verified the exact hex from the bug report converts to the exact bech32 address shown in the auth dialog.

## Testing

- New `src/__tests__/addressCompatibility.test.ts` covering the exact failing hex address, testnet/reward variants, bech32 passthrough, and non-address input (5 tests, all pass)
- Existing multisig SDK tests pass (22)
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)