### PR TITLE
fix(import): make cross-instance import work from mobile and other origins

### DIFF
--- a/src/components/pages/homepage/wallets/import-wallet-flow/source/instance-tab.tsx
+++ b/src/components/pages/homepage/wallets/import-wallet-flow/source/instance-tab.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
+import { normalizeAddressToBech32 } from "@/utils/addressCompatibility";
 
 import type {
   ResolvedWalletPayload,
@@ -246,7 +247,11 @@ async function getStakeAddress(wallet: unknown): Promise<string | null> {
   const rewardAddresses = await (
     wallet as { getRewardAddresses: () => Promise<string[]> }
   ).getRewardAddresses();
-  return rewardAddresses[0] ?? null;
+  const raw = rewardAddresses[0];
+  if (!raw) return null;
+  // Mobile in-app browsers return hex-encoded CBOR bytes here; Mesh's
+  // signData and the origin's bech32 signer list both need bech32.
+  return normalizeAddressToBech32(raw);
 }
 
 async function fetchNonce(
@@ -255,7 +260,7 @@ async function fetchNonce(
   address: string,
 ): Promise<string> {
   const url = `${origin}/api/v1/exportWallet/getNonce?walletId=${encodeURIComponent(walletId)}&address=${encodeURIComponent(address)}`;
-  const res = await fetch(url, { credentials: "omit" });
+  const res = await fetchFromOrigin(url, { credentials: "omit" });
   const body = await res.json().catch(() => ({}));
   if (!res.ok) {
     throw new Error(body.error || `Origin returned ${res.status}`);
@@ -275,7 +280,7 @@ async function fetchRedeem(
     key: string;
   },
 ): Promise<{ payload: ResolvedWalletPayload; payloadHash: string }> {
-  const res = await fetch(`${origin}/api/v1/exportWallet/redeem`, {
+  const res = await fetchFromOrigin(`${origin}/api/v1/exportWallet/redeem`, {
     method: "POST",
     credentials: "omit",
     headers: { "Content-Type": "application/json" },
@@ -296,12 +301,31 @@ async function fetchList(
   address: string,
 ): Promise<RemoteWalletSummary[]> {
   const url = `${origin}/api/v1/exportWallet/listMine?address=${encodeURIComponent(address)}`;
-  const res = await fetch(url, { credentials: "omit" });
+  const res = await fetchFromOrigin(url, { credentials: "omit" });
   const body = await res.json().catch(() => ({}));
   if (!res.ok) {
     throw new Error(body.error || `Origin returned ${res.status}`);
   }
   return Array.isArray(body.wallets) ? body.wallets : [];
+}
+
+/**
+ * Cross-origin fetch failures surface as an opaque TypeError ("Load failed"
+ * on Safari, "Failed to fetch" on Chrome) whether the origin is down, runs
+ * an older version without the exportWallet API, or rejects CORS. Translate
+ * that into something the user can act on.
+ */
+async function fetchFromOrigin(
+  input: string,
+  init?: RequestInit,
+): Promise<Response> {
+  try {
+    return await fetch(input, init);
+  } catch {
+    throw new Error(
+      "Couldn't reach the origin. It may be offline, blocking cross-origin requests, or running a version without export support.",
+    );
+  }
 }
 
 function policyLabel(w: RemoteWalletSummary): string {

--- a/src/components/pages/homepage/wallets/import-wallet-flow/source/json-tab.tsx
+++ b/src/components/pages/homepage/wallets/import-wallet-flow/source/json-tab.tsx
@@ -3,6 +3,7 @@ import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 
 import type {
@@ -21,22 +22,25 @@ interface Props {
  * wallet info page: an envelope with `payload` and `payloadHash`. We
  * verify the hash server-side too (during importWallet), but checking
  * client-side gives faster feedback if the file is corrupt.
+ *
+ * Accepts either a file or pasted JSON text — mobile in-app browsers
+ * often can't reach the downloaded file, but can paste from clipboard.
  */
 export default function JsonTab({ flow }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
   const [sourceInstance, setSourceInstance] = useState("");
+  const [pastedJson, setPastedJson] = useState("");
 
-  const handleFile = async (file: File) => {
+  const handleText = (text: string) => {
     try {
-      const text = await file.text();
       const parsed = JSON.parse(text) as {
         payload?: ResolvedWalletPayload;
         payloadHash?: string;
         sourceInstance?: string;
       };
       if (!parsed.payload || typeof parsed.payloadHash !== "string") {
-        throw new Error("File is missing payload or payloadHash");
+        throw new Error("Backup is missing payload or payloadHash");
       }
       if (parsed.payload.schemaVersion !== 1) {
         throw new Error("Unsupported schema version");
@@ -52,10 +56,22 @@ export default function JsonTab({ flow }: Props) {
       });
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "Failed to read JSON file";
+        err instanceof Error ? err.message : "Failed to read JSON backup";
+      toast({
+        title: "Invalid backup",
+        description: message,
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleFile = async (file: File) => {
+    try {
+      handleText(await file.text());
+    } catch {
       toast({
         title: "Invalid backup file",
-        description: message,
+        description: "Could not read the selected file",
         variant: "destructive",
       });
     }
@@ -67,8 +83,8 @@ export default function JsonTab({ flow }: Props) {
         <p className="font-medium">From a JSON backup</p>
         <p className="mt-1 text-muted-foreground">
           Drop in a file produced by the <em>Download JSON backup</em>{" "}
-          action on the wallet info page. We'll verify the payload hash
-          before creating the local record.
+          action on the wallet info page, or paste its contents below.
+          We'll verify the payload hash before creating the local record.
         </p>
       </div>
 
@@ -98,16 +114,42 @@ export default function JsonTab({ flow }: Props) {
             if (file) void handleFile(file);
           }}
         />
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            onClick={() => inputRef.current?.click()}
+            className="w-full sm:w-auto"
+          >
+            Choose file
+          </Button>
+        </div>
       </div>
 
-      <div className="flex justify-end">
-        <Button
-          variant="outline"
-          onClick={() => inputRef.current?.click()}
-          className="w-full sm:w-auto"
-        >
-          Choose file
-        </Button>
+      <div className="flex items-center gap-3">
+        <div className="h-px flex-1 bg-border/40" />
+        <span className="text-xs uppercase text-muted-foreground">or</span>
+        <div className="h-px flex-1 bg-border/40" />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="backup-json">Paste backup JSON</Label>
+        <Textarea
+          id="backup-json"
+          placeholder='{"payload": {…}, "payloadHash": "…"}'
+          value={pastedJson}
+          onChange={(e) => setPastedJson(e.target.value)}
+          rows={6}
+          className="font-mono text-xs"
+        />
+        <div className="flex justify-end">
+          <Button
+            onClick={() => handleText(pastedJson)}
+            disabled={!pastedJson.trim()}
+            className="w-full sm:w-auto"
+          >
+            Import pasted JSON
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -59,6 +59,25 @@ export const cors = initMiddleware(
   }),
 );
 
+/**
+ * Public CORS for endpoints that are *meant* to be called from arbitrary
+ * other origins (cross-instance wallet export). These endpoints carry no
+ * cookies (clients fetch with credentials: "omit") and are protected by
+ * CIP-30 signature verification instead, so reflecting any origin is safe.
+ * The allowlist-based `cors` above would reject unknown instances and the
+ * browser surfaces that as an opaque "Load failed" network error.
+ */
+export const publicCors = initMiddleware(
+  Cors({
+    methods: ["GET", "POST", "OPTIONS"],
+    allowedHeaders: ["Content-Type"],
+    credentials: false,
+    optionsSuccessStatus: 200,
+    preflightContinue: false,
+    origin: "*",
+  }),
+);
+
 // Helper function to add cache-busting headers for CORS
 export function addCorsCacheBustingHeaders(res: NextApiResponse) {
   res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');

--- a/src/pages/api/v1/exportWallet/getNonce.ts
+++ b/src/pages/api/v1/exportWallet/getNonce.ts
@@ -1,8 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { randomBytes } from "crypto";
 import { db } from "@/server/db";
-import { cors, addCorsCacheBustingHeaders } from "@/lib/cors";
+import { publicCors, addCorsCacheBustingHeaders } from "@/lib/cors";
 import { applyRateLimit } from "@/lib/security/requestGuards";
+import { normalizeAddressToBech32 } from "@/utils/addressCompatibility";
 
 /**
  * Cross-instance export nonce.
@@ -25,7 +26,7 @@ export default async function handler(
     return;
   }
 
-  await cors(req, res);
+  await publicCors(req, res);
   if (req.method === "OPTIONS") {
     return res.status(200).end();
   }
@@ -35,10 +36,13 @@ export default async function handler(
   }
 
   try {
-    const { address, walletId } = req.query;
-    if (typeof address !== "string" || typeof walletId !== "string") {
+    const { address: rawAddress, walletId } = req.query;
+    if (typeof rawAddress !== "string" || typeof walletId !== "string") {
       return res.status(400).json({ error: "Missing address or walletId" });
     }
+    // Mobile CIP-30 wallets may hand the importer a hex-encoded address;
+    // signer lists store bech32, so normalize before membership checks.
+    const address = normalizeAddressToBech32(rawAddress);
 
     const wallet = await db.wallet.findUnique({ where: { id: walletId } });
     if (!wallet) {

--- a/src/pages/api/v1/exportWallet/listMine.ts
+++ b/src/pages/api/v1/exportWallet/listMine.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { db } from "@/server/db";
-import { cors, addCorsCacheBustingHeaders } from "@/lib/cors";
+import { publicCors, addCorsCacheBustingHeaders } from "@/lib/cors";
 import { applyRateLimit } from "@/lib/security/requestGuards";
+import { normalizeAddressToBech32 } from "@/utils/addressCompatibility";
 
 /**
  * Cross-instance wallet list for the import wizard's "instance root + picker"
@@ -24,7 +25,7 @@ export default async function handler(
     return;
   }
 
-  await cors(req, res);
+  await publicCors(req, res);
   if (req.method === "OPTIONS") {
     return res.status(200).end();
   }
@@ -33,10 +34,11 @@ export default async function handler(
     return res.status(405).end();
   }
 
-  const { address } = req.query;
-  if (typeof address !== "string" || address.length === 0) {
+  const { address: rawAddress } = req.query;
+  if (typeof rawAddress !== "string" || rawAddress.length === 0) {
     return res.status(400).json({ error: "Missing address" });
   }
+  const address = normalizeAddressToBech32(rawAddress);
 
   try {
     const wallets = await db.wallet.findMany({

--- a/src/pages/api/v1/exportWallet/redeem.ts
+++ b/src/pages/api/v1/exportWallet/redeem.ts
@@ -2,8 +2,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { createHash } from "crypto";
 import { db } from "@/server/db";
 import { checkSignature, DataSignature } from "@meshsdk/core";
-import { cors, addCorsCacheBustingHeaders } from "@/lib/cors";
+import { publicCors, addCorsCacheBustingHeaders } from "@/lib/cors";
 import { applyRateLimit, enforceBodySize } from "@/lib/security/requestGuards";
+import { normalizeAddressToBech32 } from "@/utils/addressCompatibility";
 import { nonceKey } from "./getNonce";
 
 /**
@@ -30,7 +31,7 @@ export default async function handler(
     return;
   }
 
-  await cors(req, res);
+  await publicCors(req, res);
   if (req.method === "OPTIONS") {
     return res.status(200).end();
   }
@@ -41,7 +42,11 @@ export default async function handler(
 
   if (!enforceBodySize(req, res, 64 * 1024)) return;
 
-  const { address, walletId, signature, key } = req.body ?? {};
+  const { address: rawAddress, walletId, signature, key } = req.body ?? {};
+  const address =
+    typeof rawAddress === "string"
+      ? normalizeAddressToBech32(rawAddress)
+      : rawAddress;
   if (
     typeof address !== "string" ||
     typeof walletId !== "string" ||


### PR DESCRIPTION
## Summary

Fixes the two failures seen when importing a wallet from another multisig instance on mobile (in-app wallet browsers), plus a mobile-friendly JSON paste option.

### 1. "Origin request failed — Load failed" (CORS)

The three `exportWallet` endpoints (`getNonce`, `redeem`, `listMine`) used the allowlist-based `cors` middleware, which rejects any origin not in `CORS_ORIGINS` (default: empty). A rejected origin made the handler 500 without an `Access-Control-Allow-Origin` header, which Safari reports as the opaque "Load failed".

These endpoints are *designed* for cross-instance calls — clients fetch with `credentials: "omit"` and ownership is proven by CIP-30 signature, not cookies — so they now use a new `publicCors` middleware (`Access-Control-Allow-Origin: *`, no credentials).

### 2. "Failed to sign nonce" / empty wallet list (hex addresses)

`instance-tab.tsx` passed the raw `getRewardAddresses()[0]` — hex-encoded CBOR bytes in mobile in-app browsers — into Mesh `signData` (throws on hex) and into the origin's bech32 signer-list check (never matches). Same class of bug as #273, which missed this flow.

- Client: normalize the stake address to bech32 via the existing `normalizeAddressToBech32` helper.
- Server: defensively normalize the incoming `address` in all three endpoints so older deployed clients keep working.

### 3. UX

- Opaque cross-origin fetch failures ("Load failed" / "Failed to fetch") are translated into an actionable message (origin offline / blocking CORS / no export support).
- The **Upload JSON** tab now also accepts pasted backup JSON — mobile in-app browsers often can't access downloaded files, but can paste from the clipboard. Pasted text goes through the same payload/payloadHash/schemaVersion validation as a file.

## Note for rollout

The *source* instance must run this version too: imports fail until the remote origin serves the exportWallet endpoints with the public CORS policy.

## Test plan

- `npx tsc --noEmit` clean
- `npx jest` — 362 passed, 47 suites
- Manual: import via origin deep link + instance root picker from a mobile in-app wallet browser; paste JSON backup on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)