### PR TITLE
diag(auth): surface real wallet signData error on mobile auth failure

### DIFF
--- a/src/components/common/modals/WalletAuthModal.tsx
+++ b/src/components/common/modals/WalletAuthModal.tsx
@@ -104,20 +104,34 @@ export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuth
           signingAddress,
         )) as { signature: string; key: string };
       } catch (error: any) {
-        if (error instanceof Error) {
-          const msg = error.message.toLowerCase();
-          if (
-            msg.includes("user") ||
-            msg.includes("cancel") ||
-            msg.includes("decline") ||
-            msg.includes("reject")
-          ) {
-            throw new Error(
-              "Signing cancelled. Please try again and approve the signing request.",
-            );
-          }
+        const raw =
+          error instanceof Error
+            ? error.message
+            : typeof error === "string"
+              ? error
+              : (() => {
+                  try {
+                    return JSON.stringify(error);
+                  } catch {
+                    return String(error);
+                  }
+                })();
+        // Surface the wallet's real error — some (e.g. the UTXOS smart
+        // wallet) fail inside signData with a provider-specific message we
+        // otherwise lose. Keep the friendly cancel handling on top.
+        console.error("[WalletAuthModal] signData failed:", error);
+        const msg = (raw ?? "").toLowerCase();
+        if (
+          msg.includes("user") ||
+          msg.includes("cancel") ||
+          msg.includes("decline") ||
+          msg.includes("reject")
+        ) {
+          throw new Error(
+            "Signing cancelled. Please try again and approve the signing request.",
+          );
         }
-        throw new Error("Failed to sign nonce. Please try again.");
+        throw new Error(`Failed to sign nonce: ${raw || "unknown wallet error"}`);
       }
 
       if (!signed?.signature || !signed?.key) {


### PR DESCRIPTION
## Why

Authorizing a wallet on `multisig.quirinschlegel.com` (preprod) fails on mobile with the **UTXOS** smart wallet: the wallet's approval dialog errors with "Etwas ist schiefgelaufen" and the app shows a generic "Failed to sign nonce."

Railway logs confirm the **server is healthy** — `getNonce` succeeds for the user's bech32 address, but **no `wallet-session` request ever follows**. The failure is entirely inside the wallet's `signData`, *after* the user approves.

The blocker to diagnosing it: [WalletAuthModal.tsx](src/components/common/modals/WalletAuthModal.tsx) caught the wallet's real exception and **threw it away**, replacing it with a generic string. (Note: this is *not* a swapped-argument bug — the UTXOS `MeshWallet.signData` signature is `(payload, address)`, matching the call.)

## What

- Surface the wallet's underlying error in the toast (`Failed to sign nonce: <real message>`) and `console.error`, so the next failed attempt reveals UTXOS's actual error string.
- Preserve the existing friendly cancel/reject handling.
- Robust extraction for non-`Error` throwables (string / object).

## Next step after deploy

Retry on the device; the real UTXOS error will point to the fix — most likely the smart wallet signs data only with the stake credential (not the base address we pass) or a mainnet/preprod network mismatch.

## Test plan

- `npx tsc --noEmit` clean
- Manual: trigger an auth failure on the UTXOS in-app browser and confirm the toast now shows the provider's real message

🤖 Generated with [Claude Code](https://claude.com/claude-code)