### PR TITLE
diag(auth): show raw signData error, drop false-matching cancel heuristic

### DIFF
--- a/src/components/common/modals/WalletAuthModal.tsx
+++ b/src/components/common/modals/WalletAuthModal.tsx
@@ -116,21 +116,12 @@ export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuth
                     return String(error);
                   }
                 })();
-        // Surface the wallet's real error — some (e.g. the UTXOS smart
-        // wallet) fail inside signData with a provider-specific message we
-        // otherwise lose. Keep the friendly cancel handling on top.
+        // Surface the wallet's real error verbatim — some (e.g. the UTXOS
+        // smart wallet) fail inside signData with a provider-specific
+        // message we otherwise lose. The previous cancel/reject heuristic
+        // false-matched non-cancellation errors that merely contained the
+        // word "user", hiding the true cause, so always show the raw text.
         console.error("[WalletAuthModal] signData failed:", error);
-        const msg = (raw ?? "").toLowerCase();
-        if (
-          msg.includes("user") ||
-          msg.includes("cancel") ||
-          msg.includes("decline") ||
-          msg.includes("reject")
-        ) {
-          throw new Error(
-            "Signing cancelled. Please try again and approve the signing request.",
-          );
-        }
         throw new Error(`Failed to sign nonce: ${raw || "unknown wallet error"}`);
       }
 


### PR DESCRIPTION
## Why

Follow-up to #275. After that PR started surfacing the wallet's real `signData` error, the next mobile attempt still showed **"Signing cancelled. Please try again…"** — even though the user approved the request.

Cause: the cancel/reject heuristic matched **any** error message containing `user` / `cancel` / `decline` / `reject` and rewrote it to the generic "Signing cancelled", which hid the true UTXOS failure we were trying to capture.

## What

- Drop the heuristic; always surface the provider's raw message verbatim as `Failed to sign nonce: <real text>` (plus `console.error`).

## Next step after deploy

Retry on the UTXOS in-app browser — the toast will now show UTXOS's actual error string, which will point to the real fix (likely: signs data only with the stake credential, or a network/account mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)