### PR TITLE
fix(auth): use Mesh 1.9 wallet so signData args aren't swapped (VESPR -2)

### DIFF
--- a/src/components/common/modals/WalletAuthModal.tsx
+++ b/src/components/common/modals/WalletAuthModal.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
-import { useWallet } from "@meshsdk/react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import useUTXOS from "@/hooks/useUTXOS";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import { normalizeAddressToBech32 } from "@/utils/addressCompatibility";
 
 interface WalletAuthModalProps {
@@ -15,7 +15,16 @@ interface WalletAuthModalProps {
 }
 
 export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuthorize = false }: WalletAuthModalProps) {
-  const { wallet, connected } = useWallet();
+  // Use the Mesh 1.9 BrowserWallet (via useMeshWallet), NOT react-2.0's
+  // useWallet().wallet. The latter is a low-level CIP-30 wallet whose
+  // signData(address, payload) argument order is SWAPPED relative to 1.9's
+  // signData(payload, address). Calling it with our (nonce, address) order
+  // made wallets (e.g. VESPR) sign with the nonce as the address and throw
+  // CIP-30 InternalError (-2). The 1.9 wallet matches the (payload, address)
+  // order used everywhere else in the app, and the UTXOS MeshWallet below is
+  // also payload-first — so a single signData(nonce, address) call is correct
+  // for both.
+  const { wallet: meshWallet, connected } = useMeshWallet();
   const { wallet: utxosWallet, isEnabled: isUtxosEnabled } = useUTXOS();
   const { toast } = useToast();
   const [submitting, setSubmitting] = useState(false);
@@ -24,7 +33,7 @@ export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuth
   const signingWallet =
     isUtxosEnabled && utxosWallet?.cardano
       ? utxosWallet.cardano
-      : (wallet && connected ? wallet : null);
+      : (meshWallet && connected ? meshWallet : null);
 
   const handleAuthorize = useCallback(async () => {
     if (!signingWallet) {
@@ -98,7 +107,7 @@ export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuth
 
       let signed: { signature: string; key: string } | undefined;
       try {
-        // Mirror the working Swagger token flow: signData(nonce, address)
+        // Mesh 1.9 / UTXOS order is signData(payload, address).
         signed = (await (signingWallet as any).signData(
           nonce,
           signingAddress,


### PR DESCRIPTION
## Root cause (confirmed from device console)

Authorizing on mobile failed in VESPR with:

```
[WalletAuthModal] signData failed: {code: -2, info: 'An error occurred during execution of this API call.'}
```

`code: -2` is CIP-30 `InternalError`. The cause is a **swapped `signData` argument order**:

- `WalletAuthModal` signed with **`useWallet().wallet`** from `@meshsdk/react` 2.0 — a low-level CIP-30 wallet whose signature is **`signData(address, payload)`**.
- But it called `signData(nonce, signingAddress)`, which is Mesh **1.9** order `signData(payload, address)`.
- So the **nonce was passed as the address** and the **address as the payload**. VESPR tried to sign using a bogus signing address (the nonce) → `InternalError -2`. This also explains the earlier screenshot where the wallet showed the *address* under "Nachricht" (it was the payload).

The hazard is documented in [`useMeshWallet.ts`](src/hooks/useMeshWallet.ts): react-2.0's wallet has the args swapped vs 1.9, and "both are `string`, so a wrong-order call would compile but sign the wrong bytes." Every other signing flow in the app already avoids this by using the 1.9 `BrowserWallet`.

## Fix

- Source the signing wallet from **`useMeshWallet()`** (Mesh 1.9 `BrowserWallet`, `signData(payload, address)`) instead of `useWallet().wallet`.
- The UTXOS `MeshWallet` path is also payload-first, so the single `signData(nonce, address)` call is now correct for both wallet types — no per-wallet branching needed.

Builds on the diagnostics from #275 / #276 (which surfaced the `{code: -2}` message that pinned this down).

## Note on the `/api/trpc/user.createUser` 401 in the same console

That 401 is a downstream symptom: `createUser` is a `protectedProcedure` needing a wallet session, which never got established because signData failed. It should clear once auth succeeds; I'll verify after this deploys and follow up if it persists.

## Test plan

- `npx tsc --noEmit` clean
- Manual (post-deploy): authorize with VESPR in-app browser → signature succeeds, `wallet-session` 200, wallet authorized

🤖 Generated with [Claude Code](https://claude.com/claude-code)