### PR TITLE
refactor(wallet): consolidate all wallet ops on the Mesh 1.9 bridge + ESLint guardrail

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,23 @@ export default [
       },
     },
     rules: {
+      // Guardrail: never pull `wallet` out of @meshsdk/react 2.0's useWallet().
+      // That object is a low-level CIP-30 wallet whose signData(address, payload)
+      // / signTx(tx, partialSign) signatures differ from the @meshsdk/core 1.9
+      // IWallet the app is built on — a wrong-order call compiles but signs the
+      // wrong bytes (caused VESPR CIP-30 InternalError -2 and ballot witness
+      // divergence). Use useMeshWallet()/useActiveWallet() for any wallet ops;
+      // useWallet() is fine for connection state only (name/connected/connect/
+      // disconnect).
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "VariableDeclarator[init.callee.name='useWallet'] > ObjectPattern > Property[key.name='wallet']",
+          message:
+            "Don't destructure `wallet` from @meshsdk/react useWallet() — its signData/signTx args differ from core 1.9 and silently sign wrong bytes. Use useMeshWallet()/useActiveWallet() instead.",
+        },
+      ],
       "@typescript-eslint/array-type": "off",
       "@typescript-eslint/consistent-type-definitions": "off",
       "@typescript-eslint/consistent-type-imports": [

--- a/src/components/common/modals/WalletAuthModal.tsx
+++ b/src/components/common/modals/WalletAuthModal.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
-import { useWallet } from "@meshsdk/react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import useUTXOS from "@/hooks/useUTXOS";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import { normalizeAddressToBech32 } from "@/utils/addressCompatibility";
 
 interface WalletAuthModalProps {
@@ -15,7 +15,16 @@ interface WalletAuthModalProps {
 }
 
 export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuthorize = false }: WalletAuthModalProps) {
-  const { wallet, connected } = useWallet();
+  // Use the Mesh 1.9 BrowserWallet (via useMeshWallet), NOT react-2.0's
+  // useWallet().wallet. The latter is a low-level CIP-30 wallet whose
+  // signData(address, payload) argument order is SWAPPED relative to 1.9's
+  // signData(payload, address). Calling it with our (nonce, address) order
+  // made wallets (e.g. VESPR) sign with the nonce as the address and throw
+  // CIP-30 InternalError (-2). The 1.9 wallet matches the (payload, address)
+  // order used everywhere else in the app, and the UTXOS MeshWallet below is
+  // also payload-first — so a single signData(nonce, address) call is correct
+  // for both.
+  const { wallet: meshWallet, connected } = useMeshWallet();
   const { wallet: utxosWallet, isEnabled: isUtxosEnabled } = useUTXOS();
   const { toast } = useToast();
   const [submitting, setSubmitting] = useState(false);
@@ -24,7 +33,7 @@ export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuth
   const signingWallet =
     isUtxosEnabled && utxosWallet?.cardano
       ? utxosWallet.cardano
-      : (wallet && connected ? wallet : null);
+      : (meshWallet && connected ? meshWallet : null);
 
   const handleAuthorize = useCallback(async () => {
     if (!signingWallet) {
@@ -98,7 +107,7 @@ export function WalletAuthModal({ address, open, onClose, onAuthorized, autoAuth
 
       let signed: { signature: string; key: string } | undefined;
       try {
-        // Mirror the working Swagger token flow: signData(nonce, address)
+        // Mesh 1.9 / UTXOS order is signData(payload, address).
         signed = (await (signingWallet as any).signData(
           nonce,
           signingAddress,

--- a/src/components/common/overall-layout/layout.tsx
+++ b/src/components/common/overall-layout/layout.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, Component, ReactNode, useMemo, useCallback, useState, useRef } from "react";
 import { useRouter } from "next/router";
 import Link from "next/link";
-import { useWallet, useAddress } from "@meshsdk/react";
+import { useAddress } from "@meshsdk/react";
 import { publicRoutes } from "@/data/public-routes";
 import { api } from "@/utils/api";
 import useUser from "@/hooks/useUser";
@@ -99,7 +99,6 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { wallet } = useWallet();
   // 1.9 IWallet bridge — used for getDRep(), which the react 2.0 wallet lacks.
   const { wallet: meshWallet } = useMeshWallet();
   const { state: walletState, connectedWalletInstance } = useWalletContext();
@@ -124,9 +123,9 @@ export default function RootLayout({
   const connected = String(walletState) === String(WalletState.CONNECTED);
   const anyWalletConnected = connected || isUtxosEnabled;
   // Use connectedWalletInstance if available, otherwise fall back to wallet
-  const activeWallet = connectedWalletInstance && Object.keys(connectedWalletInstance).length > 0 
-    ? connectedWalletInstance 
-    : wallet;
+  const activeWallet = connectedWalletInstance && Object.keys(connectedWalletInstance).length > 0
+    ? connectedWalletInstance
+    : meshWallet;
 
   // Global error handler for unhandled promise rejections
   useEffect(() => {
@@ -289,8 +288,8 @@ export default function RootLayout({
     }
 
     async function initializeWallet() {
-      if (!walletAddress) return;
-      
+      if (!walletAddress || !activeWallet) return;
+
       try {
         // Get stake address
         const stakeAddresses = await activeWallet.getRewardAddresses();

--- a/src/components/common/overall-layout/mobile-wrappers/user-dropdown-wrapper.tsx
+++ b/src/components/common/overall-layout/mobile-wrappers/user-dropdown-wrapper.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useWallet } from "@meshsdk/react";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import { useToast } from "@/hooks/use-toast";
 import { useRouter } from "next/router";
 import { useUserStore } from "@/lib/zustand/user";
@@ -24,7 +25,10 @@ export default function UserDropDownWrapper({
   mode, 
   onAction 
 }: UserDropDownWrapperProps) {
-  const { wallet, connected, disconnect } = useWallet();
+  // useWallet only for connection state/control; wallet ops go through the
+  // Mesh 1.9 bridge.
+  const { connected, disconnect } = useWallet();
+  const { wallet } = useMeshWallet();
   const { wallet: utxosWallet, isEnabled: isUtxosEnabled, disable: disableUtxos } = useUTXOS();
   const { toast } = useToast();
   const router = useRouter();

--- a/src/components/common/overall-layout/user-drop-down.tsx
+++ b/src/components/common/overall-layout/user-drop-down.tsx
@@ -9,13 +9,17 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useWallet } from "@meshsdk/react";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import { useToast } from "@/hooks/use-toast";
 import { useRouter } from "next/router";
 import { useUserStore } from "@/lib/zustand/user";
 import { api } from "@/utils/api";
 
 export default function UserDropDown() {
-  const { wallet, disconnect } = useWallet();
+  // useWallet only for connection control (disconnect); wallet ops go
+  // through the Mesh 1.9 bridge.
+  const { disconnect } = useWallet();
+  const { wallet } = useMeshWallet();
   const { toast } = useToast();
   const router = useRouter();
   const setPastWallet = useUserStore((state) => state.setPastWallet);
@@ -42,6 +46,7 @@ export default function UserDropDown() {
 
   async function unlinkDiscord(): Promise<void> {
     try {
+      if (!wallet) return;
       const usedAddresses = await wallet.getUsedAddresses();
       const address = usedAddresses[0];
       unlinkDiscordMutation.mutate({ address: address ?? "" });
@@ -84,6 +89,7 @@ export default function UserDropDown() {
         <DropdownMenuItem
           onClick={async () => {
             try {
+              if (!wallet) return;
               let userAddress: string | undefined;
               try {
                 const usedAddresses = await wallet.getUsedAddresses();

--- a/src/components/pages/homepage/governance/drep/id/index.tsx
+++ b/src/components/pages/homepage/governance/drep/id/index.tsx
@@ -8,7 +8,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { Loader } from "lucide-react";
 import ActiveIndicator from "../activeIndicator";
 import ScriptIndicator from "../scriptIndicator";
-import { useWallet } from "@meshsdk/react";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import RowLabelInfo from "@/components/common/row-label-info";
 import { extractJsonLdValue } from "@/utils/jsonLdParser";
 import { Button } from "@/components/ui/button";
@@ -17,7 +17,7 @@ import DelegateButton from "./delegateButton";
 export default function DrepDetailPage() {
   const router = useRouter();
   const { id } = router.query;
-  const { wallet, connected } = useWallet();
+  const { wallet, connected } = useMeshWallet();
   const [drepInfo, setDrepInfo] = useState<BlockfrostDrepInfo | null>(null);
   const [drepMetadata, setDrepMetadata] =
     useState<BlockfrostDrepMetadata | null>(null);

--- a/src/components/pages/homepage/governance/drep/index.tsx
+++ b/src/components/pages/homepage/governance/drep/index.tsx
@@ -4,7 +4,7 @@ import Pagination from "@/components/common/overall-layout/pagination";
 import { getProvider } from "@/utils/get-provider";
 import { BlockfrostDrepInfo, BlockfrostDrepMetadata } from "@/types/governance";
 import Link from "next/link";
-import { useWallet } from "@meshsdk/react";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import DelegateButton from "./id/delegateButton";
 import RowLabelInfo from "@/components/common/row-label-info";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -16,7 +16,7 @@ export default function DrepOverviewPage() {
     Array<{ details: BlockfrostDrepInfo; metadata: BlockfrostDrepMetadata | null }>
   >([]);
   const [loading, setLoading] = useState<boolean>(true);
-  const { wallet, connected } = useWallet();
+  const { wallet, connected } = useMeshWallet();
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [pageSize, setPageSize] = useState<number>(25);
   const [order, setOrder] = useState<"asc" | "desc">("asc");

--- a/src/components/pages/homepage/wallets/import-wallet-flow/source/cbor-tab.tsx
+++ b/src/components/pages/homepage/wallets/import-wallet-flow/source/cbor-tab.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useWallet } from "@meshsdk/react";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import { resolveNativeScriptHash } from "@meshsdk/core";
 
 import { Button } from "@/components/ui/button";
@@ -33,7 +33,7 @@ interface Props {
  * don't accept anonymous garbage rows.
  */
 export default function CborTab({ flow }: Props) {
-  const { wallet, connected } = useWallet();
+  const { wallet, connected } = useMeshWallet();
   const { toast } = useToast();
 
   const [name, setName] = useState("");

--- a/src/components/pages/homepage/wallets/import-wallet-flow/source/instance-tab.tsx
+++ b/src/components/pages/homepage/wallets/import-wallet-flow/source/instance-tab.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useWallet } from "@meshsdk/react";
+import useMeshWallet from "@/hooks/useMeshWallet";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -38,7 +38,10 @@ type Mode =
  * and lets them pick before signing.
  */
 export default function InstanceTab({ flow }: Props) {
-  const { wallet, connected } = useWallet();
+  // Mesh 1.9 bridge — signData(payload, address). react-2.0's useWallet()
+  // wallet has the args swapped, which made VESPR sign the wrong bytes and
+  // throw CIP-30 InternalError (-2) during cross-instance import.
+  const { wallet, connected } = useMeshWallet();
   const { toast } = useToast();
   const [urlInput, setUrlInput] = useState("");
   const [busy, setBusy] = useState(false);

--- a/src/components/pages/wallet/governance/hydra/HydraBudgetVote.tsx
+++ b/src/components/pages/wallet/governance/hydra/HydraBudgetVote.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useWallet } from "@meshsdk/react";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import { Info, Loader, Check, X, ExternalLink } from "lucide-react";
 
 import useAppWallet from "@/hooks/useAppWallet";
@@ -53,7 +53,10 @@ interface EkklesiaSignablePayload {
 export default function HydraBudgetVote() {
   const { appWallet } = useAppWallet();
   const { multisigWallet } = useMultisigWallet();
-  const { wallet, connected } = useWallet();
+  // Mesh 1.9 bridge — signData(payload, address). Do NOT use react-2.0's
+  // useWallet().wallet here: its signData args are swapped, which silently
+  // signed the wrong bytes (the ballot witness/body-hash divergence).
+  const { wallet, connected } = useMeshWallet();
   const userAddress = useUserStore((s) => s.userAddress);
   const { toast } = useToast();
   const ctx = api.useUtils();
@@ -103,7 +106,7 @@ export default function HydraBudgetVote() {
    */
   const signDataHex = useCallback(
     async (dataHex: string): Promise<EkklesiaWitness> => {
-      if (!connected) throw new Error("Wallet not connected");
+      if (!connected || !wallet) throw new Error("Wallet not connected");
       if (!userAddress) throw new Error("User address not found");
       const sig = await wallet.signData(dataHex, userAddress);
       return { signature: sig.signature, key: sig.key };

--- a/src/components/pages/wallet/transactions/send-all.tsx
+++ b/src/components/pages/wallet/transactions/send-all.tsx
@@ -3,7 +3,7 @@ import { Wallet } from "@/types/wallet";
 import CardUI from "@/components/ui/card-content";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
-import { useWallet } from "@meshsdk/react";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import useActiveWallet from "@/hooks/useActiveWallet";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
@@ -16,7 +16,7 @@ import { getTxBuilder } from "@/utils/get-tx-builder";
 import useTransaction from "@/hooks/useTransaction";
 
 export default function CardSendAll({ appWallet }: { appWallet: Wallet }) {
-  const { wallet, connected } = useWallet();
+  const { wallet, connected } = useMeshWallet();
   const { isWalletReady } = useActiveWallet();
   // const [loading, setLoading] = useState<boolean>(false);
   const [recipientAddress, setRecipientAddress] = useState<string>("");

--- a/src/pages/api-docs.tsx
+++ b/src/pages/api-docs.tsx
@@ -1,7 +1,7 @@
 // src/pages/api-docs.tsx
 import dynamic from "next/dynamic";
 import React, { useEffect, useState, useRef } from "react";
-import { useWallet } from "@meshsdk/react";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import { Key, Lightbulb, Copy, Check } from "lucide-react";
 import Globe from "./globe";
 
@@ -13,7 +13,10 @@ const SwaggerUI = dynamic(() => import("swagger-ui-react"), { ssr: false });
 export const getServerSideProps = () => ({ props: {} });
 
 export default function ApiDocs() {
-  const { wallet, connected } = useWallet();
+  // Mesh 1.9 bridge — signData(payload, address). react-2.0's useWallet()
+  // wallet has the args swapped, which broke bearer-token generation on
+  // wallets like VESPR (CIP-30 InternalError -2).
+  const { wallet, connected } = useMeshWallet();
   const [isGeneratingToken, setIsGeneratingToken] = useState(false);
   const [generatedToken, setGeneratedToken] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import useUser from "@/hooks/useUser";
 import { useUserStore } from "@/lib/zustand/user";
-import { useWallet } from "@meshsdk/react";
+import useMeshWallet from "@/hooks/useMeshWallet";
 import { useToast } from "@/hooks/use-toast";
 import CardUI from "@/components/ui/card-content";
 import RowLabelInfo from "@/components/ui/row-label-info";
@@ -22,7 +22,7 @@ export default function UserInfoPage() {
   const { user, isLoading } = useUser();
   const userAddress = useUserStore((state) => state.userAddress);
   const userAssets = useUserStore((state) => state.userAssets);
-  const { wallet, connected } = useWallet();
+  const { wallet, connected } = useMeshWallet();
   const { wallet: utxosWallet, isEnabled: isUtxosEnabled, isLoading: isUtxosLoading, error: utxosError } = useUTXOS();
   const { walletType, isAnyWalletConnected, isWalletReady, activeWallet } = useActiveWallet();
   const { toast } = useToast();


### PR DESCRIPTION
**Stacked on #277** (base = `claude/fix-walletauth-signdata-order`). This is the "migrate to 2.0 properly, going forward" follow-up. Once #277 merges to `preprod`, GitHub auto-retargets this PR's base to `preprod`.

## The rule this enforces

> Mesh **1.9 `core`** is the signing/tx engine. `@meshsdk/react` 2.0 is **connection state only**. All wallet ops go through one bridge (`useMeshWallet` / `useActiveWallet`).

`@meshsdk/core` has no stable 2.0 yet (npm latest = `1.9.0`); only `@meshsdk/react` is at `2.0.0-beta.2`. So the correct target today is a clean, enforced boundary — not a half-migrated mix. The mix is exactly what produced the VESPR `signData -2` bug: react-2.0's `useWallet().wallet` has `signData(address, payload)` / `signTx(tx, partialSign)` signatures that differ from 1.9, so a wrong-order call compiles but signs the wrong bytes.

## Fixes 3 live latent copies of the same bug

- **HydraBudgetVote.tsx** — `signData` on the react-2.0 wallet. Very likely the source of the **ballot witness / body-hash divergence** you were instrumenting in `015fc72`.
- **instance-tab.tsx** (cross-instance import) — would fail with CIP-30 `-2` on VESPR-type wallets; my earlier import PR fixed CORS + address but not the wallet source.
- **api-docs.tsx** bearer-token generation — same swapped-args failure (ironically the "working Swagger flow" the old code comment referenced).

## Also

- Migrates the remaining **read-only** `useWallet().wallet` sites (address / network-id lookups — identical across versions, not bugs) to the bridge, so the boundary is uniform: `user-drop-down`, `user-dropdown-wrapper`, `layout`, `drep` ×2, `cbor-tab`, `send-all`, `user/index`.
- Adds null-guards where the bridge wallet is transiently `null` while enabling.
- **ESLint guardrail**: `no-restricted-syntax` makes destructuring `wallet` from `useWallet()` a **build error**. `useWallet()` stays allowed for connection state. Verified the rule **fires** on a violation and **passes** the bridge form.

## When core 2.0 ships (the real migration, later)

Because everything now funnels through `useActiveWallet`/`useMeshWallet`, the eventual core-2.0 upgrade becomes a *single-layer* change: bump the matching 2.x packages, drop the bridge in `useMeshWallet`, and fix the 2.0 deltas (`signData` arg order, `signTx(tx, partialSign)`, `getUtxos(): string[]`, removed `getDRep`/`getAssets`/`getLovelace`) in that one hook — instead of an 18-file sweep.

## Test plan

- `npx tsc --noEmit` clean
- `npx jest` — 362 passed, 47 suites
- ESLint rule verified to fire on `const { wallet } = useWallet()` and pass `const { wallet } = useMeshWallet()`
- Manual (post-deploy): VESPR auth, cross-instance import, Hydra/Ekklesia ballot vote, Swagger token generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)