### PR TITLE
fix(governance): detect on-chain DRep registration in Hydra budget vote

### DIFF
--- a/src/components/pages/wallet/governance/hydra/HydraBudgetVote.tsx
+++ b/src/components/pages/wallet/governance/hydra/HydraBudgetVote.tsx
@@ -6,6 +6,10 @@ import { Info, Loader, Check, X, ExternalLink } from "lucide-react";
 import useAppWallet from "@/hooks/useAppWallet";
 import useMultisigWallet from "@/hooks/useMultisigWallet";
 import { useUserStore } from "@/lib/zustand/user";
+import { useSiteStore } from "@/lib/zustand/site";
+import { getProvider } from "@/utils/get-provider";
+import { getDRepIds } from "@meshsdk/core-cst";
+import type { BlockfrostDrepInfo } from "@/types/governance";
 import { api } from "@/utils/api";
 import { useToast } from "@/hooks/use-toast";
 
@@ -52,7 +56,8 @@ interface EkklesiaSignablePayload {
 
 export default function HydraBudgetVote() {
   const { appWallet } = useAppWallet();
-  const { multisigWallet } = useMultisigWallet();
+  const { multisigWallet, isLoading: walletLoading } = useMultisigWallet();
+  const network = useSiteStore((s) => s.network);
   // Mesh 1.9 bridge — signData(payload, address). Do NOT use react-2.0's
   // useWallet().wallet here: its signData args are swapped, which silently
   // signed the wrong bytes (the ballot witness/body-hash divergence).
@@ -77,7 +82,31 @@ export default function HydraBudgetVote() {
   });
 
   const questions = ballot?.hydra?.ballot?.questions ?? [];
+  // Locally-derived DRep ID (always present once the wallet loads — it's a
+  // key/script derivation, NOT proof of on-chain registration).
   const dRepId = multisigWallet?.getDRepId();
+
+  // Proper detection: the wallet can only vote if this DRep is actually
+  // registered (active) on-chain — the same source the DRep Information card
+  // uses. Gating on `dRepId` alone wrongly told registered DReps to "register
+  // first", since the derivation succeeds regardless of registration.
+  const { data: isDRepRegistered, isLoading: registrationLoading } = useQuery({
+    queryKey: ["drep-registration", dRepId, network],
+    enabled: !!dRepId,
+    staleTime: 60 * 1000,
+    queryFn: async (): Promise<boolean> => {
+      const ids = getDRepIds(dRepId!);
+      try {
+        const info = (await getProvider(network).get(
+          `/governance/dreps/${ids.cip105}`,
+        )) as BlockfrostDrepInfo | undefined;
+        return info?.active === true;
+      } catch {
+        // 404 (or any lookup failure) → treat as not registered.
+        return false;
+      }
+    },
+  });
   // DRep native script for the draft body (role-3 keys, payment-script fallback).
   const nativeScript = useMemo(
     () => multisigWallet?.buildScript(3) ?? multisigWallet?.buildScript(0),
@@ -268,7 +297,23 @@ export default function HydraBudgetVote() {
 
   if (!appWallet) return null;
 
-  if (!dRepId) {
+  // Still resolving the wallet or its on-chain DRep status — don't claim the
+  // wallet isn't a DRep before we actually know.
+  if (walletLoading || !multisigWallet || (!!dRepId && registrationLoading)) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Hydra Budget Vote</CardTitle>
+          <CardDescription className="flex items-center gap-2">
+            <Loader className="h-4 w-4 animate-spin" />
+            Checking DRep registration…
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (!isDRepRegistered) {
     return (
       <Card>
         <CardHeader>


### PR DESCRIPTION
**Stacked on #278** (base = `claude/consolidate-wallet-bridge`, which already touches this file). Auto-retargets to `preprod` as the stack merges.

## Bug

The **Hydra Budget Vote** card showed *"Register this wallet as a DRep first"* even though the wallet is a fully registered, **Active** DRep with ~1M ADA voting power (the **DRep Information** card shows it correctly).

Root cause: the gate was `if (!multisigWallet?.getDRepId())`. But `getDRepId()` is a **local key/script derivation** — it returns an ID whether or not the DRep is registered on-chain, and is `undefined` only while the wallet is still loading. So the check conflated "wallet loaded" with "registered," and mis-fired.

## Fix

Detect registration the way the DRep Information card does — **on-chain**:

- Look up the DRep via Blockfrost `/governance/dreps/{cip105}` (same endpoint + `getDRepIds` helper the global wallet-data loader uses) and gate on `active === true`.
- Wrapped in React Query (`staleTime` 60s) so it's cached and gives a real **loading** state — we now show *"Checking DRep registration…"* while the wallet/registration resolves, instead of flashing the register prompt.
- `getDRepId()` is still used for the actual vote payload; only the *gate* changed.

## Result

| State | Before | After |
|---|---|---|
| Registered + active DRep | ❌ "Register first" | ✅ Vote UI |
| Still loading | ❌ "Register first" | "Checking DRep registration…" |
| Genuinely not registered | ✅ "Register first" | ✅ "Register first" |

## Test plan

- `npx tsc --noEmit` clean
- `npx jest` — 362 passed
- Manual (post-deploy): open Hydra Budget Vote on a registered-DRep multisig → vote UI renders; on a non-DRep wallet → register prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)