### PR TITLE
fix(auth): normalize all userAddress sources in layout to bech32 (stuck "Loading…")

### DIFF
--- a/src/components/common/overall-layout/layout.tsx
+++ b/src/components/common/overall-layout/layout.tsx
@@ -6,6 +6,7 @@ import { publicRoutes } from "@/data/public-routes";
 import { api } from "@/utils/api";
 import useUser from "@/hooks/useUser";
 import { useUserStore } from "@/lib/zustand/user";
+import { normalizeAddressToBech32 } from "@/utils/addressCompatibility";
 import useAppWallet from "@/hooks/useAppWallet";
 import useUTXOS from "@/hooks/useUTXOS";
 import useMeshWallet from "@/hooks/useMeshWallet";
@@ -102,7 +103,11 @@ export default function RootLayout({
   // 1.9 IWallet bridge — used for getDRep(), which the react 2.0 wallet lacks.
   const { wallet: meshWallet } = useMeshWallet();
   const { state: walletState, connectedWalletInstance } = useWalletContext();
-  const address = useAddress();
+  // react-2.0's useAddress can return hex-encoded address bytes; user records
+  // and sessions are keyed by bech32. Normalize once at the source so every
+  // consumer below (store sync, session check) uses the bech32 form.
+  const rawAddress = useAddress();
+  const address = rawAddress ? normalizeAddressToBech32(rawAddress) : rawAddress;
   const { user, isLoading: isLoadingUser } = useUser();
   const router = useRouter();
   const { appWallet } = useAppWallet();
@@ -258,7 +263,7 @@ export default function RootLayout({
       activeWallet.getUsedAddresses()
         .then((addresses) => {
           if (addresses && addresses.length > 0) {
-            setUserAddress(addresses[0]!);
+            setUserAddress(normalizeAddressToBech32(addresses[0]!));
             fetchingAddressRef.current = false;
           } else {
             return activeWallet.getUnusedAddresses();
@@ -266,7 +271,7 @@ export default function RootLayout({
         })
         .then((addresses) => {
           if (addresses && addresses.length > 0 && !userAddress) {
-            setUserAddress(addresses[0]!);
+            setUserAddress(normalizeAddressToBech32(addresses[0]!));
           }
           fetchingAddressRef.current = false;
         })


### PR DESCRIPTION
Follow-up to #281. While verifying the stuck-"Loading…" fix live on preprod via the browser, I saw `getUserByAddress` / `getWalletSession` **still** being called with the hex address form in addition to bech32.

Cause: #281 normalized the three `setUserAddress` sites, but `layout.tsx` also derives:
- `walletAddressForSession = userAddress || address`
- `walletAddressForCheck = userAddress || address`
- `walletAddress = userAddress || address` (passed to `createUser`)

…all of which fall back to the **raw** `address` from react-2.0's `useAddress()` (hex) whenever the store `userAddress` is momentarily undefined. So the session check / user create could still run against the hex form, which never matches the bech32-keyed records.

**Fix:** normalize `address` once right at `useAddress()` so every downstream consumer uses bech32. tsc clean.

## Verified live
- `getUserByAddress(addr1qyvgdy2…)` → finds the user; `getUserByAddress(0118869144…)` → null (same wallet) — documented in #281.
- After #281 deployed, the infinite "Loading…" is gone (now shows actionable "Authorize"); this PR removes the remaining hex session/createUser calls so the connected state resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)