### PR TITLE
fix(db): cap pg pool + stop retrying pool saturation (Supabase EMAXCONNSESSION)

### DIFF
--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -9,6 +9,22 @@ const INITIAL_RETRY_DELAY_MS = 500;
 
 // Check if error is a connection error that should be retried
 const isConnectionError = (error: unknown): boolean => {
+  // Pool saturation must NEVER be retried. Retrying hammers an already
+  // saturated pool and amplifies the outage. This covers the Supabase
+  // Supavisor session-mode limit (EMAXCONNSESSION / "max clients reached")
+  // and the node-postgres pool acquire timeout ("timeout exceeded when
+  // trying to connect"). Fail fast so the request errors instead of looping.
+  if (error instanceof Error) {
+    const m = error.message.toLowerCase();
+    if (
+      m.includes("max clients reached") ||
+      m.includes("pool_size") ||
+      m.includes("emaxconnsession") ||
+      m.includes("timeout exceeded when trying to connect")
+    ) {
+      return false;
+    }
+  }
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     // P1001: Can't reach database server
     // P1008: Operations timed out
@@ -55,14 +71,9 @@ const withRetry = async <T>(
       }
       
       await new Promise((resolve) => setTimeout(resolve, delay));
-      
-      // Try to reconnect before retrying
-      try {
-        await prismaClient.$connect();
-      } catch {
-        // Ignore connection errors here, let the retry handle it
-      }
-      
+
+      // Do NOT call $connect() here: the pg driver-adapter pool reconnects
+      // lazily, and forcing a connect against a saturated pool only adds load.
       return withRetry(operation, retries - 1);
     }
     throw error;
@@ -104,7 +115,20 @@ const createPrismaClient = () => {
   // Prisma 7 requires a driver adapter (or Accelerate) instead of a schema/url
   // connection. The pg adapter connects via the pooled DATABASE_URL; migrations
   // use the direct connection configured in prisma.config.ts.
-  const adapter = new PrismaPg({ connectionString: env.DATABASE_URL });
+  // Cap the node-postgres pool per serverless instance. Without `max`,
+  // node-postgres defaults to 10 connections/instance — a few warm Vercel
+  // instances overrun Supabase's session-mode pool (15 client slots) and
+  // every query fails with EMAXCONNSESSION. A small max keeps connections
+  // well under the pooler limit and preserves transaction-mode multiplexing;
+  // concurrent intra-request queries queue rather than deadlock (they each
+  // release per statement). Finite timeouts make a saturated pool fail fast
+  // instead of hanging on the pg default connectionTimeoutMillis: 0 (infinite).
+  const adapter = new PrismaPg({
+    connectionString: env.DATABASE_URL,
+    max: 2,
+    idleTimeoutMillis: 10_000,
+    connectionTimeoutMillis: 10_000,
+  });
 
   const client = new PrismaClient({
     adapter,


### PR DESCRIPTION
## Problem (production, meshjs.dev)

Every DB-backed query 500s with:
```
(EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15
```
`user.createUser`, `ballot.getByWallet`, `transaction.getPendingTransactions`, `wallet.getWallet`, … all fail.

## Root cause (confirmed live on Supabase project `wzgemhfjyfnqmhxlvkqc` + a multi-agent code audit)

- **DB topology**: `max_connections=60`, but the app connects through **Supavisor in session mode**, capped at **15 client slots** (the `pool_size: 15`).
- **Code**: `src/server/db.ts` created the `@prisma/adapter-pg` pool with **no `max`** → node-postgres defaults to **10 connections per warm Vercel instance**. ~2 instances (2×10) overrun the 15-slot pool → `EMAXCONNSESSION` everywhere.
- **Amplifier**: the retry wrapper called `$connect()` against the dead pool between retries, and would treat the pool-acquire timeout as a retryable connection error — hammering an already-saturated pool.
- Verified **not** the cause: the `globalThis` Prisma singleton is correct (one client/pool per warm instance); no per-request client creation; the 5 interactive `$transaction` blocks are pure-DB (no external I/O held), so no leak fix is needed.

## Code fix (`src/server/db.ts`)

- **Cap the pool**: `max: 2`, `idleTimeoutMillis: 10s`, `connectionTimeoutMillis: 10s` (finite → fail fast instead of pg's default infinite wait). `max: 2` keeps connections well under the pooler limit; concurrent intra-request queries queue (they release per statement), they don't deadlock.
- **Never retry pool saturation**: `isConnectionError()` now short-circuits `max clients reached` / `pool_size` / `EMAXCONNSESSION` / connect-timeout to `false`.
- **Drop the `$connect()` reconnect** between retries (driver-adapter reconnects lazily).

## Required maintainer action (env — can't be done from code)

Point production **`DATABASE_URL`** at the Supabase **Transaction pooler** (port **6543**, `?pgbouncer=true`); keep **`DIRECT_URL`** on the direct connection (5432) for migrations. Session mode (5432) is the wrong mode for serverless. The code cap above also works as an interim mitigation if the env change lags.

## Optional follow-ups surfaced by the audit (not in this PR)

- Collapse the double-query auth guard (`assertWalletAccess` `findUnique` before each wallet-scoped query) in `ballot.ts` / `transactions.ts` / `signable.ts` / `proxy.ts`.
- Replace the per-address `wallet.findUnique` loop in `proxy.ts:84` with one query + in-memory check.
- Unify `getProxiesByUserOrWallet` input shapes so React Query dedupes it.

## Test plan
- `npx tsc --noEmit` clean; `npx jest` — 362 passed.
- Post-deploy (per audit): `SELECT count(*), state, application_name FROM pg_stat_activity GROUP BY state, application_name;` stays low/stable under load; hard-reload an authenticated wallet-governance page 5–10× across tabs → no `EMAXCONNSESSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)