### PR TITLE
docs(roadmap): month-by-month breakdown with per-owner tasks

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,59 +42,216 @@ Status of M1 tasks. Last updated 2026-04-23.
 
 ---
 
-## Months 2–3 — June–July 2026
+## Month 2 — June 2026
 
-**Direction:** Authentication, Summon migration, collateral service, minor fixes.
+**Focus:** Mesh 2.0 upgrade and CI improvements.
 
-- Improved authentication — nonce-based auth, wallet connection fixes, registration flow (#135, #53)
-- Summon migration — land API routes and wallet import (PR #212, PR #208)
-- Collateral service — 22 ADA → 4 UTxOs for proxy collateral (#221)
-- Full address verification (#196)
-- Transaction pagination (#30)
-- Better 404 page (#22)
-- Monthly report
+**Quirin**
 
----
+| Task | Issues |
+|------|--------|
+| Mesh 2.0 upgrade — migrate to Mesh SDK 2.0 | |
 
-## Months 4–6 — August–October 2026
+**Andre**
 
-**Direction:** Governance, smart contracts, and on-chain wallet discovery.
-
-- Aiken crowdfund integration (PR #164)
-- Governance metadata fix (#122)
-- Proxy voting polish and documentation
-- Wallet V2 — on-chain registration and discovery (#33)
-- Pending transactions on homepage (#125)
-- FROST research kickoff (#220)
-- Backlog cleanup, dependency/security updates
-- Monthly reports
+| Task | Issues |
+|------|--------|
+| CI improvements | |
 
 ---
 
-## Months 7–9 — November 2026–January 2027
+## Month 3 — July 2026
 
-**Direction:** Ecosystem integrations and developer experience.
+**Focus:** On-chain wallet discovery and FROST kickoff.
 
-- Hardware wallet support — Ledger/Trezor (#44)
-- Bot platform v2 — SDK, webhooks, example bots
-- dApp connector — external dApps request multi-sig transactions
-- API documentation and developer portal
-- FROST research — deliver findings, PoC, go/no-go (#220)
-- Monthly reports
+**Quirin**
+
+| Task | Issues |
+|------|--------|
+| FROST research kickoff | #220 |
+
+**Andre**
+
+| Task | Issues |
+|------|--------|
+| Wallet V2 — on-chain registration and discovery | #33 |
 
 ---
 
-## Months 10–12 — February–April 2027
+## Month 4 — August 2026
 
-**Direction:** Growth features, polish, and wrap-up.
+**Focus:** Document Sign-Off MVP — build (see [Flagship feature](#flagship-feature--document-sign-off)).
 
-- Vesting — time-locked multi-sig contracts (#81)
-- User profiles and contacts
-- Discover page — browse wallets, DAOs, governance (#52)
-- Performance and UX audit
-- Invite flow (PR #67)
-- Final summary report — activity, outcomes, gaps, next steps
-- Monthly reports
+**Quirin**
+
+| Task | Issues |
+|------|--------|
+| Document Sign-Off MVP (build) — 5-table data model, four routes, CIP-8 signature enforcement, version-hash binding | |
+
+**Andre**
+
+| Task | Issues |
+|------|--------|
+| Document Sign-Off MVP (build) — Documents section UI, six-state lifecycle, signer review screen | |
+
+---
+
+## Month 5 — September 2026
+
+**Focus:** Document Sign-Off MVP — ship (8–10 wk effort completes).
+
+**Quirin**
+
+| Task | Issues |
+|------|--------|
+| Document Sign-Off MVP (ship) — proof export (JSON + PDF), verify route | |
+
+**Andre**
+
+| Task | Issues |
+|------|--------|
+| Document Sign-Off MVP (ship) — diffs where feasible, status grouping, polish | |
+| Monthly report | |
+
+---
+
+## Month 6 — October 2026
+
+**Focus:** Document Sign-Off provenance, FROST findings, hardware wallets.
+
+**Quirin**
+
+| Task | Issues |
+|------|--------|
+| Document Sign-Off v1 — Provenance (history, diff & rollback, richer audit export) | |
+| FROST research — deliver findings, PoC, go/no-go | #220 |
+
+**Andre**
+
+| Task | Issues |
+|------|--------|
+| Hardware wallet support — Ledger/Trezor | #44 |
+
+---
+
+## Month 7 — November 2026
+
+**Focus:** Governance polish, dApp connector, bot platform.
+
+**Quirin**
+
+| Task | Issues |
+|------|--------|
+| Governance metadata fix | #122 |
+| dApp connector — external dApps request multi-sig transactions | |
+
+**Andre**
+
+| Task | Issues |
+|------|--------|
+| Pending transactions on homepage | #125 |
+| Bot platform v2 — SDK, webhooks, example bots | |
+
+---
+
+## Month 8 — December 2026
+
+**Focus:** Proxy voting, testing, developer experience.
+
+**Quirin**
+
+| Task | Issues |
+|------|--------|
+| Proxy voting polish and documentation | |
+| Transaction builder & tRPC integration tests | #255 |
+
+**Andre**
+
+| Task | Issues |
+|------|--------|
+| API documentation and developer portal | |
+| Backlog cleanup, dependency/security updates | |
+| Monthly report | |
+
+---
+
+## Month 9 — January 2027
+
+**Focus:** Document Sign-Off checkpoints, vesting, growth.
+
+**Quirin**
+
+| Task | Issues |
+|------|--------|
+| Document Sign-Off v2 — Checkpoints (opt-in on-chain anchoring in Cardano metadata) | |
+| Vesting — time-locked multi-sig contracts | #81 |
+
+**Andre**
+
+| Task | Issues |
+|------|--------|
+| User profiles and contacts | |
+
+---
+
+## Month 10 — February 2027
+
+**Focus:** Invite flow and discovery.
+
+**Quirin**
+
+| Task | Issues |
+|------|--------|
+| Invite flow | PR #67 |
+
+**Andre**
+
+| Task | Issues |
+|------|--------|
+| Discover page — browse wallets, DAOs, governance | #52 |
+
+---
+
+## Month 11 — March 2027
+
+**Focus:** Polish, wrap-up, and forward-looking research.
+
+**Quirin**
+
+| Task | Issues |
+|------|--------|
+| Performance and UX audit | |
+| Final summary report — activity, outcomes, gaps, next steps | |
+
+**Andre**
+
+| Task | Issues |
+|------|--------|
+| Document Sign-Off v3 — Collaboration & standards (CRDT/QES bridge — scoped as research) | |
+| Monthly report | |
+
+---
+
+## Month 12 — April 2027
+
+**Focus:** Buffer / catch-up — absorb slippage from earlier months, finalize reporting, plan next cycle.
+
+No fixed feature commitments; reserved for spillover, stabilization, and next-roadmap planning.
+
+---
+
+## Flagship feature — Document Sign-Off
+
+A wallet-native, off-chain document approval layer: bind approval to an exact version hash, inherit the wallet's signer set + threshold, and collect CIP-8 sign-off (approve/reject) per signer. No new chain, no new token, no change to the transaction model — delivered as a Documents section inside the wallet.
+
+| Phase | Scope | Months |
+|-------|-------|--------|
+| MVP — Sign-off | Documents section, six-state lifecycle, version-hash binding, signer review, exportable JSON+PDF proof. Off-chain. | M4–M5 |
+| v1 — Provenance | Revision history first-class, diff & rollback, richer audit export (off-chain). | M6 |
+| v2 — Checkpoints | Optional on-chain anchoring of a version's hash + parent in Cardano tx metadata. | M9 |
+| v3 — Collaboration & standards | Real-time co-authoring (CRDT), metadata standard (CIP candidate), eIDAS/EUDI QES bridge. | M11 (research) |
+
+**Data model:** five entities (`Document`, `DocumentVersion`, `DocumentReview`, `DocumentSignerSnapshot`, `DocumentEvent`) + optional `Checkpoint`, all reusing wallet signer identity and threshold. Approval belongs to a version, never a mutable container; a new version starts a fresh round at zero approvals.
 
 ---
 
@@ -102,10 +259,11 @@ Status of M1 tasks. Last updated 2026-04-23.
 
 | Topic | Description | Months | Owner |
 |-------|-------------|--------|-------|
-| **FROST multi-sig wallets** | Research FROST (Flexible Round-Optimized Schnorr Threshold) signatures for Cardano. Evaluate feasibility of replacing or complementing native script multi-sig with threshold Schnorr signatures — smaller on-chain footprint, better privacy (single signature on-chain), and flexible threshold schemes. Investigate Cardano-compatible FROST libraries, protocol readiness, and migration path from current native scripts. | 6-9 | Quirin |
+| **FROST & PQC multi-sig wallets** | Research FROST (Flexible Round-Optimized Schnorr Threshold) signatures for Cardano. Evaluate feasibility of replacing or complementing native script multi-sig with threshold Schnorr signatures — smaller on-chain footprint, better privacy (single signature on-chain), and flexible threshold schemes. Investigate Cardano-compatible FROST libraries, protocol readiness, and migration path from current native scripts. Also evaluate **Lemour post-quantum (PQC) multi-sig** — lattice-based threshold signatures for long-term quantum resistance — as a forward-looking alternative/complement to FROST. | M3 (kickoff) – M6 (findings) | Quirin |
 
 **Research deliverables:**
 - Written summary of FROST vs native script trade-offs
+- Assessment of Lemour PQC multi-sig — maturity, libraries, and quantum-resistance trade-offs vs FROST
 - Proof-of-concept if libraries are available
 - Go/no-go recommendation for integration into the platform
 
@@ -145,33 +303,34 @@ Aggregated view of the 12-month roadmap split by contributor. Each task has a si
 - [M1] Fix transaction loading bug (#211)
 - [M1] Handle external PR — Summon API routes (PR #212)
 - [M1] Fix legacy wallet compatibility bug
-- [M2–3] Improved authentication — nonce-based auth, wallet connection fixes, registration flow (#135, #53)
-- [M2–3] Full address verification (#196)
-- [M2–3] Transaction pagination (#30)
-- [M4–6] Aiken crowdfund integration (PR #164)
-- [M4–6] Governance metadata fix (#122)
-- [M4–6] Proxy voting polish and documentation
-- [M4–6] FROST research kickoff (#220)
-- [M7–9] dApp connector — external dApps request multi-sig transactions
-- [M7–9] FROST research — deliver findings, PoC, go/no-go (#220)
-- [M10–12] Vesting — time-locked multi-sig contracts (#81)
-- [M10–12] Performance and UX audit
-- [M10–12] Invite flow (PR #67)
-- [M10–12] Final summary report
+- [M2] Mesh 2.0 upgrade — migrate to Mesh SDK 2.0
+- [M3] FROST research kickoff (#220)
+- [M4–5] Document Sign-Off MVP — data model, routes, CIP-8 enforcement, proof export
+- [M6] Document Sign-Off v1 — Provenance (history, diff & rollback, audit export)
+- [M6] FROST research — deliver findings, PoC, go/no-go (#220)
+- [M7] Governance metadata fix (#122)
+- [M7] dApp connector — external dApps request multi-sig transactions
+- [M8] Proxy voting polish and documentation
+- [M8] Transaction builder & tRPC integration tests (#255)
+- [M9] Document Sign-Off v2 — Checkpoints (opt-in on-chain anchoring)
+- [M9] Vesting — time-locked multi-sig contracts (#81)
+- [M10] Invite flow (PR #67)
+- [M11] Performance and UX audit
+- [M11] Final summary report
 
 ### Andre
 
 - [M1] Improve repository infrastructure — preprod environment and comprehensive smoke CI
 - [M1] CI smoke tests on real chain (#213)
 - [M1] Handle external PR — capability-based metadata (PR #208)
-- [M2–3] Summon migration — land API routes and wallet import (PR #212, PR #208)
-- [M2–3] Collateral service — 22 ADA → 4 UTxOs for proxy collateral (#221)
-- [M2–3] Better 404 page (#22)
-- [M4–6] Wallet V2 — on-chain registration and discovery (#33)
-- [M4–6] Pending transactions on homepage (#125)
-- [M4–6] Backlog cleanup, dependency/security updates
-- [M7–9] Hardware wallet support — Ledger/Trezor (#44)
-- [M7–9] Bot platform v2 — SDK, webhooks, example bots
-- [M7–9] API documentation and developer portal
-- [M10–12] User profiles and contacts
-- [M10–12] Discover page — browse wallets, DAOs, governance (#52)
+- [M2] CI improvements
+- [M3] Wallet V2 — on-chain registration and discovery (#33)
+- [M4–5] Document Sign-Off MVP — Documents UI, six-state lifecycle, signer review, diffs
+- [M6] Hardware wallet support — Ledger/Trezor (#44)
+- [M7] Pending transactions on homepage (#125)
+- [M7] Bot platform v2 — SDK, webhooks, example bots
+- [M8] API documentation and developer portal
+- [M8] Backlog cleanup, dependency/security updates
+- [M9] User profiles and contacts
+- [M10] Discover page — browse wallets, DAOs, governance (#52)
+- [M11] Document Sign-Off v3 — Collaboration & standards (research)


### PR DESCRIPTION
## Summary

Reworks `ROADMAP.md` into a month-by-month plan with per-owner task tables.

- **Month-by-month:** former grouped quarters (M2–3, M4–6, …) split into individual **Month 2–12** sections, each with **Quirin** / **Andre** task tables matching Month 1's format.
- **Document Sign-Off** added as a flagship feature (wallet-native, off-chain document approval; CIP-8 sign-off bound to a version hash) with a phase summary (MVP → v1 Provenance → v2 Checkpoints → v3 Collaboration) woven across the months.
- **Mesh 2.0 upgrade** added; **FROST research** extended to also evaluate **Lemour post-quantum (PQC) multi-sig**.
- Schedule pulled **one month earlier** (June work completed); **April** is now a buffer/catch-up month.
- Dropped already-completed items (Aiken crowdfund, full address verification, transaction pagination, collateral service, 404 page) and the June auth/Summon entries.

## Notes

Docs-only change. Targeting `preprod` per workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)