### PR TITLE
fix(governance): verify/merge witnesses with core-cst (DRep-vote signature mismatch)

### DIFF
--- a/src/__tests__/mergeSignerWitnesses.test.ts
+++ b/src/__tests__/mergeSignerWitnesses.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "@jest/globals";
-import { csl, calculateTxHash } from "@meshsdk/core-csl";
+import { csl } from "@meshsdk/core-csl";
+import { resolveTxHash } from "@meshsdk/core-cst";
 
-import { mergeSignerWitnesses } from "@/utils/txSignUtils";
+import {
+  mergeSignerWitnesses,
+  filterWitnessesToScripts,
+} from "@/utils/txSignUtils";
 
 function buildMinimalTxHex(): string {
   const inputs = csl.TransactionInputs.new();
@@ -30,78 +34,30 @@ function buildMinimalTxHex(): string {
   return csl.Transaction.new(body, witnesses, undefined).to_hex();
 }
 
-function witnessSetHexFor(
-  signer: csl.PrivateKey,
-  bodyHashHex: string,
-): string {
+// A witness-set-only payload (CIP-30 partial sign) signed over the core-cst
+// body hash of `bodyHashHex` — i.e. exactly the bytes the wallet was handed.
+function witnessSetHexFor(signer: csl.PrivateKey, bodyHashHex: string): string {
   const sig = signer.sign(Buffer.from(bodyHashHex, "hex"));
   const witness = csl.Vkeywitness.new(csl.Vkey.new(signer.to_public()), sig);
   const witnesses = csl.Vkeywitnesses.new();
   witnesses.add(witness);
-
   const witnessSet = csl.TransactionWitnessSet.new();
   witnessSet.set_vkeys(witnesses);
   return witnessSet.to_hex();
 }
 
-// Build a full signed Transaction hex whose body bytes differ from
-// `originalTxHex` (one input flipped) and whose vkey signature targets the
-// wallet's body — the shape a wallet returns when it re-canonicalises CBOR
-// before signing.
-function fullSignedTxHexWithDifferentBody(
-  originalTxHex: string,
-  signer: csl.PrivateKey,
-): { hex: string; walletBodyHashHex: string } {
-  const inputs = csl.TransactionInputs.new();
-  inputs.add(
-    csl.TransactionInput.new(
-      csl.TransactionHash.from_bytes(Buffer.from("11".repeat(32), "hex")),
-      0,
-    ),
-  );
-
-  const orig = csl.Transaction.from_hex(originalTxHex);
-  const body = csl.TransactionBody.new(
-    inputs,
-    orig.body().outputs(),
-    orig.body().fee(),
-    undefined,
-  );
-
-  // Build a transient tx (no witnesses) just to take its body hash.
-  const probeHex = csl.Transaction.new(
-    body,
-    csl.TransactionWitnessSet.new(),
-    undefined,
-  ).to_hex();
-  const walletBodyHashHex = calculateTxHash(probeHex);
-
-  const sig = signer.sign(Buffer.from(walletBodyHashHex, "hex"));
-  const vkeys = csl.Vkeywitnesses.new();
-  vkeys.add(csl.Vkeywitness.new(csl.Vkey.new(signer.to_public()), sig));
-  const witnessSet = csl.TransactionWitnessSet.new();
-  witnessSet.set_vkeys(vkeys);
-
-  // Re-parse the body so it's not consumed by the probe tx above.
-  return {
-    hex: csl.Transaction.new(
-      csl.TransactionBody.from_bytes(body.to_bytes()),
-      witnessSet,
-      undefined,
-    ).to_hex(),
-    walletBodyHashHex,
-  };
-}
-
 describe("mergeSignerWitnesses", () => {
-  it("returns an empty invalidVkeyPubKeysHex when the new vkey verifies", () => {
+  it("accepts a vkey signed over the core-cst body hash and preserves the body", () => {
     const txHex = buildMinimalTxHex();
     const signer = csl.PrivateKey.generate_ed25519();
-    const payload = witnessSetHexFor(signer, calculateTxHash(txHex));
+    const payload = witnessSetHexFor(signer, resolveTxHash(txHex));
 
     const result = mergeSignerWitnesses(txHex, payload);
 
     expect(result.invalidVkeyPubKeysHex).toEqual([]);
+    // Body bytes are unchanged: the persisted/submitted hash equals what the
+    // wallet signed — no node-side InvalidWitnessesUTXOW.
+    expect(resolveTxHash(result.txHex)).toEqual(resolveTxHash(txHex));
     expect(
       csl.Transaction.from_hex(result.txHex).witness_set().vkeys()?.len(),
     ).toBe(1);
@@ -110,10 +66,7 @@ describe("mergeSignerWitnesses", () => {
   it("flags a vkey whose signature targets a different body", () => {
     const txHex = buildMinimalTxHex();
     const signer = csl.PrivateKey.generate_ed25519();
-
-    // Sign a hash that does NOT match the body — simulates a wallet that
-    // re-canonicalised the CBOR before signing, producing a witness whose
-    // signature verifies against the wallet's re-encoded body but not ours.
+    // Signed over a hash that isn't this body's — must be reported, not adopted.
     const payload = witnessSetHexFor(signer, "ff".repeat(32));
 
     const result = mergeSignerWitnesses(txHex, payload);
@@ -122,51 +75,22 @@ describe("mergeSignerWitnesses", () => {
       .toString("hex")
       .toLowerCase();
     expect(result.invalidVkeyPubKeysHex).toEqual([expectedPubKey]);
-
-    // The merged tx still contains the witness (callers decide what to do);
-    // we just surface the validity verdict.
-    expect(
-      csl.Transaction.from_hex(result.txHex).witness_set().vkeys()?.len(),
-    ).toBe(1);
   });
 
-  it("adopts the wallet's body when the wallet returned a full signed tx whose body differs and there are no pre-existing witnesses", () => {
-    // First-signer scenario: the wallet re-canonicalised the body before
-    // signing. We should use the wallet's body (so the signature verifies)
-    // and report no invalid vkeys.
-    const txHex = buildMinimalTxHex();
-    const signer = csl.PrivateKey.generate_ed25519();
-    const { hex: walletSignedHex, walletBodyHashHex } =
-      fullSignedTxHexWithDifferentBody(txHex, signer);
-
-    // Sanity: the wallet's body hash is NOT the original body hash.
-    expect(walletBodyHashHex).not.toEqual(calculateTxHash(txHex));
-
-    const result = mergeSignerWitnesses(txHex, walletSignedHex);
-
-    expect(result.invalidVkeyPubKeysHex).toEqual([]);
-    expect(calculateTxHash(result.txHex)).toEqual(walletBodyHashHex);
-  });
-
-  it("does not re-verify witnesses that were already present", () => {
+  it("merges a co-signer without re-verifying existing witnesses and keeps the body stable", () => {
     const txHex = buildMinimalTxHex();
     const existingSigner = csl.PrivateKey.generate_ed25519();
     const newSigner = csl.PrivateKey.generate_ed25519();
 
-    // Pre-seed an "invalid" existing witness (signed against the wrong body).
-    // mergeSignerWitnesses should not flag it; only newly merged ones.
-    const wrongHashHex = "ff".repeat(32);
-    const sig = existingSigner.sign(Buffer.from(wrongHashHex, "hex"));
-    const existingWitness = csl.Vkeywitness.new(
-      csl.Vkey.new(existingSigner.to_public()),
-      sig,
-    );
+    // Pre-seed an existing witness signed against the wrong body. The merge must
+    // not re-flag it (only newly added witnesses are verified).
+    const sig = existingSigner.sign(Buffer.from("ff".repeat(32), "hex"));
     const tx = csl.Transaction.from_hex(txHex);
     const witnessSet = csl.TransactionWitnessSet.from_bytes(
       tx.witness_set().to_bytes(),
     );
     const vkeys = csl.Vkeywitnesses.new();
-    vkeys.add(existingWitness);
+    vkeys.add(csl.Vkeywitness.new(csl.Vkey.new(existingSigner.to_public()), sig));
     witnessSet.set_vkeys(vkeys);
     const seededTxHex = csl.Transaction.new(
       csl.TransactionBody.from_bytes(tx.body().to_bytes()),
@@ -174,16 +98,86 @@ describe("mergeSignerWitnesses", () => {
       tx.auxiliary_data(),
     ).to_hex();
 
-    // Merge a valid signature from a different signer.
-    const goodPayload = witnessSetHexFor(
-      newSigner,
-      calculateTxHash(seededTxHex),
-    );
+    const goodPayload = witnessSetHexFor(newSigner, resolveTxHash(seededTxHex));
     const result = mergeSignerWitnesses(seededTxHex, goodPayload);
 
     expect(result.invalidVkeyPubKeysHex).toEqual([]);
+    expect(resolveTxHash(result.txHex)).toEqual(resolveTxHash(seededTxHex));
     expect(
       csl.Transaction.from_hex(result.txHex).witness_set().vkeys()?.len(),
     ).toBe(2);
+  });
+});
+
+describe("filterWitnessesToScripts", () => {
+  it("drops vkeys not required by the native script while preserving the body", () => {
+    // Build a tx whose witness set carries a native script requiring signer A,
+    // plus vkey witnesses from A (required) and B (extraneous).
+    const A = csl.PrivateKey.generate_ed25519();
+    const B = csl.PrivateKey.generate_ed25519();
+
+    const inputs = csl.TransactionInputs.new();
+    inputs.add(
+      csl.TransactionInput.new(
+        csl.TransactionHash.from_bytes(Buffer.from("00".repeat(32), "hex")),
+        0,
+      ),
+    );
+    const outputs = csl.TransactionOutputs.new();
+    const outAddr = csl.EnterpriseAddress.new(
+      csl.NetworkInfo.testnet_preview().network_id(),
+      csl.Credential.from_keyhash(A.to_public().hash()),
+    ).to_address();
+    outputs.add(
+      csl.TransactionOutput.new(outAddr, csl.Value.new(csl.BigNum.from_str("1000000"))),
+    );
+    const body = csl.TransactionBody.new(
+      inputs,
+      outputs,
+      csl.BigNum.from_str("100000"),
+      undefined,
+    );
+
+    const nativeScript = csl.ScriptPubkey.new(A.to_public().hash());
+    const scripts = csl.NativeScripts.new();
+    scripts.add(csl.NativeScript.new_script_pubkey(nativeScript));
+
+    const probeHex = csl.Transaction.new(
+      csl.TransactionBody.from_bytes(body.to_bytes()),
+      csl.TransactionWitnessSet.new(),
+      undefined,
+    ).to_hex();
+    const bodyHash = resolveTxHash(probeHex);
+
+    const vkeys = csl.Vkeywitnesses.new();
+    vkeys.add(csl.Vkeywitness.new(csl.Vkey.new(A.to_public()), A.sign(Buffer.from(bodyHash, "hex"))));
+    vkeys.add(csl.Vkeywitness.new(csl.Vkey.new(B.to_public()), B.sign(Buffer.from(bodyHash, "hex"))));
+    const witnessSet = csl.TransactionWitnessSet.new();
+    witnessSet.set_vkeys(vkeys);
+    witnessSet.set_native_scripts(scripts);
+
+    const txHex = csl.Transaction.new(
+      csl.TransactionBody.from_bytes(body.to_bytes()),
+      witnessSet,
+      undefined,
+    ).to_hex();
+
+    const filtered = filterWitnessesToScripts(txHex);
+
+    // B is dropped, A kept, body unchanged.
+    expect(
+      csl.Transaction.from_hex(filtered).witness_set().vkeys()?.len(),
+    ).toBe(1);
+    expect(resolveTxHash(filtered)).toEqual(resolveTxHash(txHex));
+    const keptPub = csl.Transaction.from_hex(filtered)
+      .witness_set()
+      .vkeys()!
+      .get(0)
+      .vkey()
+      .public_key()
+      .as_bytes();
+    expect(Buffer.from(keptPub).toString("hex")).toEqual(
+      Buffer.from(A.to_public().as_bytes()).toString("hex"),
+    );
   });
 });

--- a/src/server/api/routers/transactions.ts
+++ b/src/server/api/routers/transactions.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { csl, calculateTxHash } from "@meshsdk/core-csl";
+import { csl } from "@meshsdk/core-csl";
+import { resolveTxHash } from "@meshsdk/core-cst";
 import { resolvePaymentKeyHash } from "@meshsdk/core";
 import { buildMultisigWallet } from "@/utils/common";
 import { getProvider } from "@/utils/get-provider";
@@ -248,7 +249,10 @@ export const transactionRouter = createTRPCRouter({
       // Check if any signature matches wallet signers
       let hasValidSignature = false;
       const signedAddresses: string[] = [];
-      const txHashHex = calculateTxHash(parsedTx.to_hex()).toLowerCase();
+      // Verify signatures against the core-cst body hash (the build serializer),
+      // so multisig signatures on Conway votes are recognised. Equal to the old
+      // core-csl hash for ordinary txs.
+      const txHashHex = resolveTxHash(parsedTx.to_hex()).toLowerCase();
       const txHashBytes = Buffer.from(txHashHex, "hex");
 
       for (let i = 0; i < vkeyWitnesses.len(); i++) {

--- a/src/utils/txScriptRecovery.ts
+++ b/src/utils/txScriptRecovery.ts
@@ -3,7 +3,8 @@ import {
   deserializeAddress,
   serializeNativeScript,
 } from "@meshsdk/core";
-import { csl, deserializeNativeScript, calculateTxHash } from "@meshsdk/core-csl";
+import { csl, deserializeNativeScript } from "@meshsdk/core-csl";
+import { resolveTxHash } from "@meshsdk/core-cst";
 import type {
   MultisigSubmissionWallet,
   ScriptRecoveryWallet,
@@ -506,7 +507,10 @@ export function diagnoseTxWitnesses(txHex: string): {
   stale: { pubKeyHex: string; keyHashHex: string }[];
 } {
   const tx = csl.Transaction.from_hex(txHex);
-  const bodyHash = calculateTxHash(txHex).toLowerCase();
+  // Hash with core-cst (the build serializer) so this matches the body hash the
+  // node computes from the submitted bytes — core-csl's calculateTxHash
+  // re-serializes the body and would false-flag valid Conway-vote witnesses.
+  const bodyHash = resolveTxHash(txHex).toLowerCase();
   const bodyHashBytes = Buffer.from(bodyHash, "hex");
   const vkeys = tx.witness_set().vkeys();
   const total = vkeys ? vkeys.len() : 0;

--- a/src/utils/txSignUtils.ts
+++ b/src/utils/txSignUtils.ts
@@ -1,8 +1,33 @@
-import { csl, calculateTxHash } from "@meshsdk/core-csl";
+import { csl } from "@meshsdk/core-csl";
+import {
+  resolveTxHash,
+  addVKeyWitnessSetToTransaction,
+  Transaction as CstTransaction,
+  TxCBOR,
+  CborSet,
+  VkeyWitness,
+} from "@meshsdk/core-cst";
 import {
   decodeNativeScriptFromCsl,
   collectSigKeyHashes,
 } from "@/utils/nativeScriptUtils";
+
+// The tx is BUILT with core-cst (MeshTxBuilder's default CardanoSDK serializer),
+// so the wallet signs the body hash core-cst produces. The old verify path used
+// core-csl's calculateTxHash, which re-serializes the body to *different* bytes
+// (notably Conway `voting_procedures` map order / set tag 258) — a different
+// hash, so valid witnesses failed to verify ("witness does not verify against tx
+// body hash"). Everything here now hashes and merges via core-cst so build and
+// verify agree, and the original body bytes every signer signed are preserved.
+//
+// core-cst VkeyWitness.toCore() returns a [pubKeyHex, signatureHex] tuple.
+function cstVkeyPubKeyHex(vkw: { toCore: () => unknown }): string {
+  const core = vkw.toCore() as unknown;
+  const pub = Array.isArray(core)
+    ? (core[0] as string)
+    : ((core as { vkey: string }).vkey);
+  return String(pub).toLowerCase();
+}
 
 function toKeyHashHex(publicKey: csl.PublicKey): string {
   return Array.from(publicKey.hash().to_bytes())
@@ -139,95 +164,57 @@ export function addUniqueVkeyWitnessToTx(
   };
 }
 
-function extractFullSignedTx(
-  signedPayloadHex: string,
-): csl.Transaction | undefined {
-  try {
-    return csl.Transaction.from_hex(signedPayloadHex);
-  } catch {
-    return undefined;
-  }
-}
-
 export function mergeSignerWitnesses(
   originalTxHex: string,
   signedPayloadHex: string,
 ): { txHex: string; invalidVkeyPubKeysHex: string[] } {
   const originalTx = csl.Transaction.from_hex(originalTxHex);
-  const originalBodyBytes = Buffer.from(originalTx.body().to_bytes());
 
-  // Some wallets re-canonicalise the tx body before signing (notably with Conway
-  // `voting_procedures`). Their vkey witness then targets *their* body hash, not
-  // ours. If the wallet returned a full Transaction (vs just a witness set) and
-  // we have no pre-existing witnesses to invalidate, prefer their body — that's
-  // what the signature is actually over.
-  const signedTx = extractFullSignedTx(signedPayloadHex);
-  const existingVkeysCount = originalTx.witness_set().vkeys()?.len() ?? 0;
-  let bodyToUse = csl.TransactionBody.from_bytes(originalTx.body().to_bytes());
-  if (signedTx) {
-    const walletBodyBytes = Buffer.from(signedTx.body().to_bytes());
-    const bodiesDiffer = !originalBodyBytes.equals(walletBodyBytes);
-    if (bodiesDiffer && existingVkeysCount === 0) {
-      // [ballot-witness-diag] First signer: adopt the wallet's re-canonicalised
-      // body so the signature matches (unchanged behaviour, now logged).
-      bodyToUse = csl.TransactionBody.from_bytes(signedTx.body().to_bytes());
-      console.warn(
-        "[ballot-witness-diag] wallet re-canonicalised tx body; adopting wallet body (first signer)",
-      );
-    } else if (bodiesDiffer) {
-      // [ballot-witness-diag] Co-signer: body-swap is skipped because earlier
-      // witnesses exist, so this signature stays bound to the wallet's encoding
-      // and may be stale against the stored body we persist/submit.
-      console.warn(
-        "[ballot-witness-diag] wallet re-canonicalised tx body but existing witnesses present — co-signer witness may be stale against stored body",
-        { existingVkeysCount },
-      );
-    }
-  }
-
-  const witnessSetClone = csl.TransactionWitnessSet.from_bytes(
-    originalTx.witness_set().to_bytes(),
-  );
-
+  // Key hashes already witnessed by earlier co-signers — don't re-verify those.
   const existingKeyHashes = new Set<string>();
-  const existingVkeys = witnessSetClone.vkeys();
+  const existingVkeys = originalTx.witness_set().vkeys();
   if (existingVkeys) {
     for (let i = 0; i < existingVkeys.len(); i++) {
       existingKeyHashes.add(toKeyHashHex(existingVkeys.get(i).vkey().public_key()));
     }
   }
 
-  const mergedVkeys = cloneVkeyWitnesses(witnessSetClone);
-
+  // The wallet's freshly-added vkey witnesses (it returns a witness-set-only
+  // payload on partial sign, or a full tx), deduped against existing.
   const incomingVkeys = extractVkeyWitnesses(signedPayloadHex);
-  mergeUniqueWitnesses(mergedVkeys, incomingVkeys);
-
-  witnessSetClone.set_vkeys(mergedVkeys);
-
-  const mergedTx = csl.Transaction.new(
-    bodyToUse,
-    witnessSetClone,
-    originalTx.auxiliary_data(),
-  );
-  if (!originalTx.is_valid()) {
-    mergedTx.set_is_valid(false);
+  const newVkeys = csl.Vkeywitnesses.new();
+  const seen = new Set<string>();
+  for (let i = 0; i < incomingVkeys.len(); i++) {
+    const witness = incomingVkeys.get(i);
+    const keyHash = toKeyHashHex(witness.vkey().public_key());
+    if (existingKeyHashes.has(keyHash) || seen.has(keyHash)) continue;
+    seen.add(keyHash);
+    newVkeys.add(witness);
   }
 
-  const txHex = mergedTx.to_hex();
-
-  // Verify each *newly added* vkey witness against the merged tx body hash.
-  // Even after the body-swap recovery above, a wallet that returns *only* a
-  // witness set (no body) can still produce a witness over an encoding we
-  // don't have. Surface that so callers can abort before persisting.
+  // Verify each new witness against the core-cst hash of the ORIGINAL body —
+  // the exact bytes the wallet signed. No more body-swap workaround: with a
+  // consistent (core-cst) encoder there's nothing to reconcile, and every
+  // co-signer signs the same stored body.
+  const bodyHashBytes = Buffer.from(resolveTxHash(originalTxHex), "hex");
   const invalidVkeyPubKeysHex: string[] = [];
-  const bodyHashBytes = Buffer.from(calculateTxHash(txHex), "hex");
-  for (let i = 0; i < mergedVkeys.len(); i++) {
-    const witness = mergedVkeys.get(i);
+  for (let i = 0; i < newVkeys.len(); i++) {
+    const witness = newVkeys.get(i);
     const pubKey = witness.vkey().public_key();
-    if (existingKeyHashes.has(toKeyHashHex(pubKey))) continue;
     if (!pubKey.verify(bodyHashBytes, witness.signature())) {
       invalidVkeyPubKeysHex.push(toPubKeyHex(pubKey));
     }
+  }
+
+  // Merge the new witnesses into the original tx WITHOUT re-encoding the body.
+  // addVKeyWitnessSetToTransaction parses with the same (core-cst) serializer
+  // used to build the tx and preserves the original body bytes, so the
+  // persisted/submitted body hash stays equal to what every signer signed.
+  let txHex = originalTxHex;
+  if (newVkeys.len() > 0) {
+    const newWitnessSet = csl.TransactionWitnessSet.new();
+    newWitnessSet.set_vkeys(newVkeys);
+    txHex = addVKeyWitnessSetToTransaction(originalTxHex, newWitnessSet.to_hex());
   }
 
   return { txHex, invalidVkeyPubKeysHex };
@@ -268,13 +255,14 @@ export function filterWitnessesToScripts(txHex: string): string {
     return txHex;
   }
 
-  const filteredVkeys = csl.Vkeywitnesses.new();
+  // Pub keys (by hex) whose key hash is required by a native script — keep only
+  // these. Analysis is read-only via core-csl; the rebuild below is core-cst.
+  const allowedPubKeyHexes = new Set<string>();
   let removed = 0;
   for (let i = 0; i < existingVkeys.len(); i++) {
-    const w = existingVkeys.get(i);
-    const kh = toKeyHashHex(w.vkey().public_key());
-    if (allowedKeyHashes.has(kh)) {
-      filteredVkeys.add(w);
+    const pub = existingVkeys.get(i).vkey().public_key();
+    if (allowedKeyHashes.has(toKeyHashHex(pub))) {
+      allowedPubKeyHexes.add(toPubKeyHex(pub));
     } else {
       removed += 1;
     }
@@ -284,21 +272,26 @@ export function filterWitnessesToScripts(txHex: string): string {
     return txHex;
   }
 
-  const witnessSetClone = csl.TransactionWitnessSet.from_bytes(
-    witnessSet.to_bytes(),
-  );
-  witnessSetClone.set_vkeys(filteredVkeys);
-
-  const filteredTx = csl.Transaction.new(
-    csl.TransactionBody.from_bytes(tx.body().to_bytes()),
-    witnessSetClone,
-    tx.auxiliary_data(),
-  );
-  if (!tx.is_valid()) {
-    filteredTx.set_is_valid(false);
+  // Drop the extraneous vkeys WITHOUT re-encoding the body: rebuild the witness
+  // set with core-cst, which preserves the original body bytes (so the
+  // remaining witnesses stay valid against the submitted body hash).
+  const cstTx = CstTransaction.fromCbor(TxCBOR(txHex));
+  const cstWitnessSet = cstTx.witnessSet();
+  const cstVkeys = cstWitnessSet.vkeys();
+  if (!cstVkeys) {
+    return txHex;
   }
-
-  return filteredTx.to_hex();
+  const keptVkeys = [...cstVkeys.values()].filter((vkw) =>
+    allowedPubKeyHexes.has(cstVkeyPubKeyHex(vkw)),
+  );
+  cstWitnessSet.setVkeys(
+    CborSet.fromCore(
+      keptVkeys.map((vkw) => vkw.toCore()),
+      VkeyWitness.fromCore,
+    ),
+  );
+  cstTx.setWitnessSet(cstWitnessSet);
+  return cstTx.toCbor();
 }
 
 export {


### PR DESCRIPTION
## Problem (production)

DRep votes fail client-side with **"Wallet returned witness that does not verify against tx body hash"** (the toast: *"The Cardano SDK and your wallet disagree on CBOR encoding"*), and such a tx would be rejected on-chain with `InvalidWitnessesUTXOW`.

## Root cause (found via multi-agent audit + verified empirically)

The vote tx is **built with core-cst** (`MeshTxBuilder`'s default CardanoSDK serializer — `getTxBuilder(useCslSerializer = false)`), so the wallet signs the body hash **core-cst** produces. But the witness **verify + merge** used **core-csl** (whisky) — `calculateTxHash` / `csl.Transaction.new(...).to_hex()` — which **re-serializes** the body to *different* bytes (Conway `voting_procedures` map order, set tag 258). Different bytes → different blake2b hash → the wallet's valid signature fails to verify.

The two serializers produce **identical** bytes for ordinary txs (verified), so only Conway-vote-shaped txs broke. This is the "witness/body-hash divergence" the team instrumented in #271.

## Fix — move verify/merge/hash onto core-cst (the 2.0 stack, already a dep)

Build and verify now use **one** encoder, and the original body bytes every signer signed are preserved:

- **`mergeSignerWitnesses`** — verify new witnesses against `resolveTxHash(originalTx)`; merge via `addVKeyWitnessSetToTransaction` (preserves body bytes). Removes the body-swap workaround, so every co-signer signs the same stored body (fixes the co-signer "stale witness" problem too).
- **`filterWitnessesToScripts`** — rebuild the witness set with core-cst so dropping extraneous vkeys no longer re-encodes the body.
- **`diagnoseTxWitnesses`** + the server signature check in **`transactions.ts`** — hash with `resolveTxHash` so multisig vote signatures are recognised (identical to the old hash for ordinary txs).

Chosen per the maintainer's direction to move toward Mesh 2.0: the lagging piece was the 1.9 core-csl verify path; everything else (build, the Mesh wallet) is already core-cst.

## Verified

- New invariant tests: adding/filtering vkeys via core-cst **preserves `resolveTxHash`**; a witness over `resolveTxHash` verifies; co-signers accumulate without re-encoding; extraneous vkeys are dropped with the body unchanged.
- `npx tsc --noEmit` clean; `npx jest` — **362 passed**.
- ⚠️ Cannot e2e-test wallet signing here (no wallet) — **needs a real VESPR vote on preprod** to confirm end-to-end before promoting to main.

## Follow-up (separate PR)

The **server v1 bot path** (`signTransaction.ts:245/342` + `addUniqueVkeyWitnessToTx`) still uses core-csl `calculateTxHash` / re-encoding and needs the same core-cst migration for bot-submitted votes. Left out to keep this PR focused on the user-facing client path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)