### PR TITLE
feat(mobile): viewport-fit + dvh + safe-area insets (foundations)

### DIFF
--- a/src/components/common/overall-layout/layout.tsx
+++ b/src/components/common/overall-layout/layout.tsx
@@ -520,7 +520,7 @@ export default function RootLayout({
   const walletIdForMenu = useMemo(() => (router.query.wallet as string) || lastVisitedWalletId || undefined, [router.query.wallet, lastVisitedWalletId]);
 
   return (
-    <div className="flex h-screen w-screen flex-col overflow-hidden">
+    <div className="flex h-[100dvh] w-screen flex-col overflow-hidden">
       {/* Skip link for keyboard users */}
       <a
         href="#main-content"
@@ -599,7 +599,7 @@ export default function RootLayout({
         {/* Sidebar for larger screens - hidden only on public homepage (not logged in) */}
         {(isLoggedIn || !isHomepage) && (
           <aside className="hidden w-[260px] border-r border-gray-300/50 bg-muted/40 dark:border-white/[0.03] md:block lg:w-[280px]">
-            <div className="flex h-full max-h-screen flex-col">
+            <div className="flex h-full max-h-[100dvh] flex-col">
               <nav className="flex-1 pt-2 overflow-y-auto">
                 <div className="flex flex-col">
                   {/* 1. Home Link - only when NOT logged in */}

--- a/src/components/ui/metatags.tsx
+++ b/src/components/ui/metatags.tsx
@@ -27,7 +27,10 @@ export default function Metatags({
 
   return (
     <Head>
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, viewport-fit=cover"
+      />
       <meta charSet="utf-8" />
 
       <title>{title}</title>

--- a/src/components/ui/mobile-navigation.tsx
+++ b/src/components/ui/mobile-navigation.tsx
@@ -53,7 +53,7 @@ export function MobileNavigation({ showWalletMenu, isLoggedIn, walletId, fallbac
         <div
           className="fixed z-40 bg-white/50 dark:bg-black/50 transition-opacity duration-200"
           style={{
-            top: '56px',
+            top: 'calc(56px + env(safe-area-inset-top))',
             left: 0,
             right: 0,
             bottom: 0,
@@ -121,7 +121,11 @@ export function MobileNavigation({ showWalletMenu, isLoggedIn, walletId, fallbac
             "data-[state=open]:animate-in data-[state=closed]:animate-out",
             "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left"
           )}
-          style={{ top: '56px', height: 'calc(100vh - 56px)' }}
+          style={{
+            top: 'calc(56px + env(safe-area-inset-top))',
+            height: 'calc(100dvh - 56px - env(safe-area-inset-top))',
+            paddingBottom: 'env(safe-area-inset-bottom)',
+          }}
           onOpenAutoFocus={(e) => {
             // Blur any focused elements in the header to prevent aria-hidden conflicts
             const header = document.querySelector('[data-header="main"]');

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ const sheetVariants = cva(
       side: {
         top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          "inset-x-0 bottom-0 border-t pb-[max(1.5rem,env(safe-area-inset-bottom))] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
           "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -66,7 +66,7 @@ const MyApp: AppType<{ session: Session | null }> = ({
       )}
       <SessionProvider session={session}>
         <div className={GeistSans.className}>
-          <div className="flex min-h-screen w-full flex-col">
+          <div className="flex min-h-[100dvh] w-full flex-col">
             <RootLayout>
               <Component {...pageProps} />
             </RootLayout>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -329,6 +329,19 @@ header[data-header="main"] {
   max-height: var(--header-height-base);
 }
 
+/* Mobile: grow the main header by the safe-area inset so the bar sits below the
+   notch/status bar, and honor side insets in landscape. Only applies below the
+   md breakpoint (the sidebar layout is hidden there). */
+@media (max-width: 767px) {
+  header[data-header="main"] {
+    padding-top: env(safe-area-inset-top);
+    padding-left: max(0.5rem, env(safe-area-inset-left));
+    padding-right: max(1rem, env(safe-area-inset-right));
+    min-height: calc(var(--header-height-base) + env(safe-area-inset-top));
+    max-height: calc(var(--header-height-base) + env(safe-area-inset-top));
+  }
+}
+
 /* Ensure parent containers don't affect alignment */
 aside > div > header[data-header="sidebar"] {
   /* Remove any inherited transforms or positioning */


### PR DESCRIPTION
**PR 1 of 6** in the mobile + UX quick-wins pass ([plan](https://github.com/MeshJS/multisig)).

The app is used heavily from phones and wallet in-app browsers (VESPR/Eternl), but had no mobile viewport handling — `h-screen`/`100vh` (clipped by dynamic toolbars), no `viewport-fit=cover`, and no `env(safe-area-inset-*)` (headers under the notch, content under the home bar).

## Changes
- **`metatags.tsx`** — viewport meta → `…, viewport-fit=cover` (required for safe-area insets to resolve at all).
- **dvh** — `_app.tsx` `min-h-screen`→`min-h-[100dvh]`; `layout.tsx` root `h-screen`→`h-[100dvh]` and inner `max-h-screen`→`max-h-[100dvh]`.
- **Safe areas** — main header grows by `env(safe-area-inset-top)` below `md` (clears the notch) + side insets in landscape (`globals.css`); mobile nav drawer offsets top by the inset, uses `100dvh`, pads the home bar; bottom `Sheet` variant pads the bottom inset.

Desktop is untouched (insets are 0; the header rule is scoped `max-width: 767px`).

## Verify
- Chrome MCP: `resize_window` 390×844 / 360×780 (and 844×390 landscape) → header clears the status bar, mobile nav's last item clears the home bar, no double scrollbar.
- Real device (iOS Safari + VESPR/Eternl in-app browser) — the dvh/safe-area behavior emulation only approximates.
- `tsc` clean; `jest` 362 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)