### PR TITLE
feat(mobile): >=44px touch targets on coarse-pointer devices

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -703,3 +703,21 @@ body.add-wallet-glass-page #logo-header svg {
 .force-scroll-container::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.3);
 }
+
+/* Touch devices: enforce ~44px minimum tap targets on interactive controls
+   without changing desktop density. Scoped to coarse pointers so mouse/laptop
+   layouts are untouched; intentionally not applied to plain text links. */
+@media (pointer: coarse) {
+  button,
+  a[role="button"],
+  [role="button"] {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  input:not([type="checkbox"]):not([type="radio"]),
+  select,
+  textarea {
+    min-height: 44px;
+  }
+}


### PR DESCRIPTION
**PR 2 of 6** in the mobile + UX quick-wins pass.

Buttons (`h-8`/`h-9`/icon `h-9 w-9`) and copy/action buttons (`h-7`) were below the 44px touch-target minimum. Rather than edit `button.tsx` cva sizes (which would change desktop density across hundreds of call sites), a single `@media (pointer: coarse)` rule in `globals.css` enlarges `button`/`[role="button"]`/`input`/`select`/`textarea` to ≥44px **on touch devices only**. Plain text links are excluded; `checkbox`/`radio` inputs are excluded.

## Verify
- Chrome MCP mobile emulation (sets `pointer: coarse`) → toolbar + recipient-row buttons screenshot ≥44px.
- Desktop (fine pointer) → zero visual change.

CSS-only; no tsc/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)