### PR TITLE
feat(ux): Skeleton + EmptyState primitives; fix blank pages & loading/empty bug

### DIFF
--- a/src/components/common/empty-state.tsx
+++ b/src/components/common/empty-state.tsx
@@ -1,0 +1,46 @@
+import { type LucideIcon } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Consistent empty-state card: an optional icon, a title, optional description,
+ * and an optional call-to-action. Replaces the ad-hoc plain-text "No X yet"
+ * strings scattered across the app.
+ */
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <Card className={cn("border-dashed", className)}>
+      <CardContent className="flex flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+        {Icon && (
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <Icon className="h-6 w-6" />
+          </div>
+        )}
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{title}</p>
+          {description && (
+            <p className="max-w-sm text-sm text-muted-foreground">
+              {description}
+            </p>
+          )}
+        </div>
+        {action && <div className="mt-1">{action}</div>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/pages/wallet/assets/index.tsx
+++ b/src/components/pages/wallet/assets/index.tsx
@@ -1,10 +1,11 @@
 import useAppWallet from "@/hooks/useAppWallet";
 import WalletAssets from "./wallet-assets";
+import WalletDetailSkeleton from "@/components/pages/wallet/wallet-detail-skeleton";
 
 export default function PageTransactions() {
   const { appWallet } = useAppWallet();
 
-  if (appWallet === undefined) return <></>;
+  if (appWallet === undefined) return <WalletDetailSkeleton />;
 
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-8">

--- a/src/components/pages/wallet/governance/index.tsx
+++ b/src/components/pages/wallet/governance/index.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Vote, Waves, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import WalletDetailSkeleton from "@/components/pages/wallet/wallet-detail-skeleton";
 
 function PageGovernanceContent() {
   const { appWallet } = useAppWallet();
@@ -35,7 +36,7 @@ function PageGovernanceContent() {
       0,
     ) ?? 0;
 
-  if (appWallet === undefined) return <></>;
+  if (appWallet === undefined) return <WalletDetailSkeleton />;
   return (
     <>
       <main className="flex flex-1 flex-col gap-4 p-3 sm:p-4 md:gap-6 lg:gap-8 lg:p-8 max-w-7xl mx-auto w-full">

--- a/src/components/pages/wallet/governance/proposals.tsx
+++ b/src/components/pages/wallet/governance/proposals.tsx
@@ -32,6 +32,7 @@ import { UTxO } from "@meshsdk/core";
 import useMultisigWallet from "@/hooks/useMultisigWallet";
 import { Badge } from "@/components/ui/badge";
 import { CheckCircle2, XCircle, MinusCircle, ChevronDown, ChevronUp, Clock, Calendar, Coins, Hash, FileText, Plus } from "lucide-react";
+import { EmptyState } from "@/components/common/empty-state";
 import { useProxy } from "@/hooks/useProxy";
 import { useProxyData } from "@/lib/zustand/proxy";
 import { useBallotModal } from "@/hooks/useBallotModal";
@@ -885,9 +886,11 @@ export default function AllProposals({ appWallet, utxos, selectedBallotId, onSel
           </div>
         )}
         {proposals.length === 0 && !isLoading && (
-          <div className="text-center py-8 text-gray-500 dark:text-gray-400">
-            <p className="text-sm sm:text-base">No proposals found.</p>
-          </div>
+          <EmptyState
+            icon={FileText}
+            title="No proposals found"
+            description="There are no governance proposals to show here right now."
+          />
         )}
       </div>
     </CardUI>

--- a/src/components/pages/wallet/info/index.tsx
+++ b/src/components/pages/wallet/info/index.tsx
@@ -9,12 +9,13 @@ import { DownloadBackup } from "./download-backup";
 import { UpgradeStakingWallet } from "./upgrade-staking-wallet";
 import ProxyControlCard from "./proxy-control";
 import { UpgradeGovernanceWallet } from "./upgrade-governance-wallet";
+import WalletDetailSkeleton from "@/components/pages/wallet/wallet-detail-skeleton";
 
 export default function WalletInfo() {
   const { appWallet } = useAppWallet();
   const { multisigWallet } = useMultisigWallet();
 
-  if (appWallet === undefined) return <></>;
+  if (appWallet === undefined) return <WalletDetailSkeleton />;
 
   return (
     <main className="flex w-full flex-1 flex-col gap-4 p-3 sm:p-4 md:gap-6 md:p-6 lg:gap-8 lg:p-8 max-w-7xl mx-auto">

--- a/src/components/pages/wallet/transactions/all-transactions.tsx
+++ b/src/components/pages/wallet/transactions/all-transactions.tsx
@@ -7,7 +7,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { ArrowUpRight, MoreHorizontal, Award, UserMinus, UserPlus, UserCog } from "lucide-react";
+import { ArrowUpRight, MoreHorizontal, Award, UserMinus, UserPlus, UserCog, ArrowLeftRight } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/common/empty-state";
 import LinkCardanoscan from "@/components/common/link-cardanoscan";
 import { Wallet } from "@/types/wallet";
 import useAllTransactions from "@/hooks/useAllTransactions";
@@ -76,8 +78,24 @@ export default function AllTransactions({ appWallet }: { appWallet: Wallet }) {
     setCurrentPage(1);
   }, [appWallet.id, walletTransactions?.length]);
 
+  // Distinguish loading (store value not yet populated) from genuinely empty.
   if (walletTransactions === undefined)
-    return <div className="text-center">No transactions yet</div>;
+    return (
+      <div className="space-y-2">
+        {[0, 1, 2].map((i) => (
+          <Skeleton key={i} className="h-14 w-full" />
+        ))}
+      </div>
+    );
+
+  if (walletTransactions.length === 0)
+    return (
+      <EmptyState
+        icon={ArrowLeftRight}
+        title="No transactions yet"
+        description="Transactions involving this wallet will appear here once it has on-chain activity."
+      />
+    );
 
   return (
     <CardUI

--- a/src/components/pages/wallet/transactions/index.tsx
+++ b/src/components/pages/wallet/transactions/index.tsx
@@ -4,6 +4,7 @@ import TransactionCard from "./transaction-card";
 import CardBalance from "./card-balance";
 import SectionTitle from "@/components/ui/section-title";
 import useAppWallet from "@/hooks/useAppWallet";
+import WalletDetailSkeleton from "@/components/pages/wallet/wallet-detail-skeleton";
 
 export default function PageTransactions() {
   const { appWallet } = useAppWallet();
@@ -12,7 +13,7 @@ export default function PageTransactions() {
     walletId: appWallet && appWallet.id,
   });
 
-  if (appWallet === undefined) return <></>;
+  if (appWallet === undefined) return <WalletDetailSkeleton />;
 
   return (
     <main className="flex flex-1 flex-col gap-4 p-4 md:gap-6 md:p-6 lg:gap-8 lg:p-8">

--- a/src/components/pages/wallet/wallet-detail-skeleton.tsx
+++ b/src/components/pages/wallet/wallet-detail-skeleton.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Placeholder shown while a wallet's data loads, instead of a blank-white flash
+ * on every wallet open. Used by the wallet detail routes (info / transactions /
+ * governance / assets) in place of returning an empty fragment.
+ */
+export default function WalletDetailSkeleton() {
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-4 p-4 md:gap-6 md:p-6 lg:gap-8 lg:p-8">
+      {[0, 1].map((i) => (
+        <div key={i} className="rounded-lg border bg-card p-6 shadow-sm">
+          <Skeleton className="h-6 w-40" />
+          <div className="mt-4 space-y-3">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        </div>
+      ))}
+    </main>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };


### PR DESCRIPTION
**PR 3 of 6** in the mobile + UX quick-wins pass.

Loading was fragmented (spinner / ad-hoc pulse / blank page) and empty states were inconsistent plain text. This adds two small primitives and adopts them at the highest-traffic spots.

## Changes
- **New `src/components/ui/skeleton.tsx`** (shadcn) and **`src/components/common/empty-state.tsx`** (Card-based: icon + title + description + optional action).
- **Blank wallet pages**: `pages/wallet/{info,transactions,governance,assets}` returned `<></>` while `appWallet` loaded → now render a shared `WalletDetailSkeleton` (kills the white flash on every wallet open — biggest perceived-quality win).
- **Loading/empty bug**: `all-transactions.tsx` showed "No transactions yet" *while still loading* (`undefined` treated as empty). Now: `undefined` → skeleton; loaded-and-empty → `EmptyState`.
- **`proposals.tsx`**: plain-text empty → `EmptyState`. (Left `ballot.tsx`'s empty state as-is — it already has an icon + actions.)

## Verify
- Chrome MCP, throttle to slow 3G → open a wallet: skeleton instead of blank. Filter to an empty list → `EmptyState`. Screenshot at 390px.
- `tsc` clean; `jest` 362 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)