### PR TITLE
fix(mobile): bech32-safe address inputs + decimal keypad + no iOS zoom

### DIFF
--- a/src/components/pages/wallet/new-transaction/RecipientRow.tsx
+++ b/src/components/pages/wallet/new-transaction/RecipientRow.tsx
@@ -107,7 +107,11 @@ function RecipientRow({
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
             <Input
-              type="string"
+              type="text"
+              inputMode="text"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
               placeholder="addr1... or $handle"
               value={recipientAddresses[index]}
               onChange={(e) => {
@@ -145,6 +149,7 @@ function RecipientRow({
         >
           <Input
             type="number"
+            inputMode="decimal"
             value={amounts[index]}
             onChange={(e) => {
               const newAmounts = [...amounts];

--- a/src/components/pages/wallet/new-transaction/RecipientRowMobile.tsx
+++ b/src/components/pages/wallet/new-transaction/RecipientRowMobile.tsx
@@ -124,7 +124,11 @@ function RecipientRowMobile({
           </label>
           <div className="flex items-center gap-2">
             <Input
-              type="string"
+              type="text"
+              inputMode="text"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
               placeholder="addr1... or $handle"
               value={recipientAddresses[index]}
               onChange={(e) => {
@@ -166,6 +170,7 @@ function RecipientRowMobile({
             </label>
             <Input
               type="number"
+              inputMode="decimal"
               value={amounts[index]}
               onChange={(e) => {
                 const newAmounts = [...amounts];

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -11,7 +11,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-9 min-w-0 w-full rounded-md border border-zinc-200 bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:placeholder:text-zinc-400 dark:focus-visible:ring-zinc-300",
+          // text-base on mobile prevents iOS Safari from zooming in on focus
+          // (any <16px font triggers it); sm:text-sm keeps the desktop density.
+          "flex h-9 min-w-0 w-full rounded-md border border-zinc-200 bg-transparent px-3 py-1 text-base sm:text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-zinc-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-800 dark:placeholder:text-zinc-400 dark:focus-visible:ring-zinc-300",
           className
         )}
         ref={ref}


### PR DESCRIPTION
**PR 6 of 6** in the mobile + UX quick-wins pass (the input-correctness slice of the address/input area).

## Changes
- **Address fields** (`RecipientRow.tsx`, `RecipientRowMobile.tsx`): invalid `type="string"` → `type="text"` + `inputMode="text" autoCapitalize="off" autoCorrect="off" spellCheck={false}`. **Correctness fix** — bech32 is case-sensitive, and mobile autocorrect/autocapitalize can silently corrupt a pasted/typed address.
- **Amount fields**: add `inputMode="decimal"` → numeric keypad on mobile.
- **Base `Input`**: `text-sm` → `text-base sm:text-sm` so iOS Safari doesn't zoom on focus (<16px triggers it); desktop density unchanged.

## Follow-up (not in this PR, same area)
Mobile pagination rework (raw `<select>` → shadcn `Select`, icon prev/next, stack at 360px) and an explicit always-visible copy-icon in `row-label-info.tsx`. Split out to keep this PR a tight correctness fix.

## Verify
- Real iOS device in VESPR/Eternl: numeric pad on amount; no autocapitalize/correct on address; no page zoom on focus. Paste a known address and confirm it's untouched.
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)