### PR TITLE
fix(mobile): keep dialogs within the viewport (responsive width + dvh + scroll)

### DIFF
--- a/src/components/pages/wallet/governance/ballot/BallotModal.tsx
+++ b/src/components/pages/wallet/governance/ballot/BallotModal.tsx
@@ -41,7 +41,7 @@ export default function BallotModal({
 }: BallotModalProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl max-h-[92vh] overflow-hidden flex flex-col p-0 gap-0">
+      <DialogContent className="max-w-5xl max-h-[90dvh] overflow-hidden flex flex-col p-0 gap-0">
         <DialogHeader className="px-6 pt-6 pb-4 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-800 flex-shrink-0">
           <div className="flex items-start justify-between gap-4">
             <div className="flex-1 min-w-0">

--- a/src/components/pages/wallet/governance/drep/RegisterDrepModal.tsx
+++ b/src/components/pages/wallet/governance/drep/RegisterDrepModal.tsx
@@ -18,7 +18,7 @@ export default function RegisterDrepModal({
 }: RegisterDrepModalProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-4xl max-h-[90dvh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Plus className="h-5 w-5" />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,11 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        // Mobile-safe sizing: stay within the viewport with a small margin
+        // (w-[calc(100%-1.5rem)]) and never exceed 90% of the dynamic viewport
+        // height, scrolling internally instead of overflowing off-screen. The
+        // max-w-lg cap and centered position are unchanged on desktop.
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100%-1.5rem)] max-w-lg max-h-[90dvh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg",
         className
       )}
       {...props}


### PR DESCRIPTION
**PR 4 of 6** in the mobile + UX quick-wins pass.

Centered `Dialog`s overflowed phones — content and action buttons clipped off-screen (worst on `WalletAuthModal`, `BallotModal` `max-w-5xl`, `RegisterDrepModal` `max-w-4xl`).

## Changes
- **Base `DialogContent`** (`dialog.tsx`): `w-full`→`w-[calc(100%-1.5rem)]` (small margin, never edge-to-edge), add `max-h-[90dvh] overflow-y-auto` (scroll internally instead of off-screen). Desktop `max-w-lg` + centered position unchanged. One edit fixes every dialog.
- **`BallotModal` / `RegisterDrepModal`**: `max-h-[9xvh]`→`max-h-[90dvh]` so the mobile toolbar doesn't hide the bottom.

## Scope note
Kept dialogs **centered** (the overflow fix is what matters) rather than converting to a mobile bottom-sheet, to avoid restructuring positioning on the shared base that backs *every* dialog without a live visual check here. Bottom-sheet can be a future enhancement.

## Verify (please do before promoting to main)
- Chrome MCP at 390px: open WalletAuthModal / BallotModal / RegisterDrepModal → fits with margins, scrolls internally, action button reachable with the keyboard open; desktop centered card unchanged.
- `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)