### PR TITLE
feat(ux): friendly-error helper + toastError wrapper

### DIFF
--- a/src/components/pages/wallet/governance/drep/registerDrep.tsx
+++ b/src/components/pages/wallet/governance/drep/registerDrep.tsx
@@ -21,6 +21,7 @@ import { useToast } from "@/hooks/use-toast";
 import { ToastAction } from "@/components/ui/toast";
 import useActiveWallet from "@/hooks/useActiveWallet";
 import { applyDRepCert } from "@/lib/tx-builders/buildDRepCertTx";
+import { getFriendlyError } from "@/utils/errors";
 
 interface PutResponse {
   url: string;
@@ -215,7 +216,7 @@ export default function RegisterDRep({ onClose }: RegisterDRepProps = {}) {
           !e.message.includes("No UTxOs")) {
         toast({
           title: "Registration Failed",
-          description: e instanceof Error ? e.message : "An unexpected error occurred during DRep registration.",
+          description: getFriendlyError(e),
           variant: "destructive",
           duration: 10000,
           action: (

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,61 @@
+/**
+ * Map raw wallet / chain / network errors to a short, human-readable message.
+ *
+ * Errors in this app come from many layers (CIP-30 wallets, Blockfrost, the
+ * UTXOS web wallet, Prisma/tRPC, Mesh) and are often surfaced verbatim in
+ * toasts — including opaque codes like CIP-30 `{ code: -2 }`. This normalizes
+ * the common cases and otherwise falls back to the raw message.
+ */
+function extractMessage(error: unknown): string {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object") {
+    const obj = error as Record<string, unknown>;
+    if (typeof obj.info === "string") return obj.info;
+    if (typeof obj.message === "string") return obj.message;
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error ?? "");
+}
+
+export function getFriendlyError(error: unknown): string {
+  const raw = extractMessage(error);
+  const m = raw.toLowerCase();
+
+  // CIP-30 APIError / DataSignError shape: { code, info }
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+  const declined =
+    m.includes("declin") ||
+    m.includes("cancel") ||
+    m.includes("reject") ||
+    m.includes("refus") ||
+    m.includes("user");
+  if (code === -2 || code === -3 || code === 2 || code === 3) {
+    return declined
+      ? "You declined the request in your wallet."
+      : "Your wallet couldn't complete the request. Please try again.";
+  }
+
+  if (m.includes("account changed"))
+    return "Your wallet account changed. Please reconnect your wallet.";
+  if (m.includes("too many requests") || m.includes("429"))
+    return "The network is busy right now. Please try again in a moment.";
+  if (m.includes("utxo balance insufficient") || m.includes("insufficient"))
+    return "Insufficient funds in this wallet for the transaction.";
+  if (m.includes("blockfrost"))
+    return "Couldn't reach the Cardano network. Please try again.";
+  if (m.includes("utxos") || m.includes("web3wallet"))
+    return "Wallet service error. Please try again.";
+  if (declined) return "Request cancelled in your wallet.";
+
+  const trimmed = raw.trim();
+  if (trimmed.length > 0 && trimmed.length < 200) return trimmed;
+  return "Something went wrong. Please try again.";
+}

--- a/src/utils/toast-error.ts
+++ b/src/utils/toast-error.ts
@@ -1,0 +1,14 @@
+import { toast } from "@/hooks/use-toast";
+import { getFriendlyError } from "@/utils/errors";
+
+/**
+ * Show a destructive toast with a normalized, human-readable message for any
+ * caught error. Use in catch blocks instead of dumping raw error strings.
+ */
+export function toastError(error: unknown, title = "Something went wrong") {
+  toast({
+    title,
+    description: getFriendlyError(error),
+    variant: "destructive",
+  });
+}


### PR DESCRIPTION
**PR 5 of 6** in the mobile + UX quick-wins pass.

Errors were surfaced verbatim in toasts — including opaque CIP-30 codes (`{code:-2}`), Blockfrost stack messages, etc.

## Changes
- **`src/utils/errors.ts`** — `getFriendlyError(error)` maps common raw errors (CIP-30 decline/`-2`, account-changed, 429, insufficient funds, Blockfrost/UTXOS, user-decline) to short human messages; falls back to the raw message, then a generic one.
- **`src/utils/toast-error.ts`** — `toastError(error, title?)` destructive-toast wrapper (additive; uses the standalone `toast`, doesn't touch the `TOAST_LIMIT=1` reducer).
- **Adopted** in DRep registration's catch — raw `e.message` → `getFriendlyError(e)`, keeping the "Copy Error" action for raw debug details.

Incremental: `new-transaction` and `WalletAuthModal` can adopt the helper next.

## Verify
- Trigger a wallet decline / force a throw → toast shows friendly text, not a raw CIP code/stack.
- `tsc` clean; `jest` 362 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)