### PR TITLE
fix(assets): stop token rows overflowing the Assets card

### DIFF
--- a/src/components/pages/wallet/assets/wallet-assets.tsx
+++ b/src/components/pages/wallet/assets/wallet-assets.tsx
@@ -4,6 +4,7 @@ import LinkCardanoscan from "@/components/common/link-cardanoscan";
 import { useWalletsStore } from "@/lib/zustand/wallets";
 import type { Wallet } from "@/types/wallet";
 import { ArrowUpRight } from "lucide-react";
+import { truncateTokenSymbol, numberWithCommas } from "@/utils/strings";
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
@@ -75,12 +76,12 @@ export default function WalletAssets({ appWallet }: { appWallet: Wallet }) {
       return (
         <div
           key={asset.unit}
-          className="flex w-full flex-row items-center justify-between"
+          className="flex w-full min-w-0 flex-row items-center justify-between gap-3"
         >
-          <div className="flex flex-row items-center gap-3">
+          <div className="flex min-w-0 flex-1 flex-row items-center gap-3">
             {imageSrc ? (
               <div
-                className={`relative flex h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-full`}
+                className={`relative flex h-[60px] w-[60px] flex-shrink-0 items-center justify-center overflow-hidden rounded-full`}
               >
                 {isImageIpfs ? (
                   <IPFSImage
@@ -102,7 +103,7 @@ export default function WalletAssets({ appWallet }: { appWallet: Wallet }) {
                 )}
               </div>
             ) : (
-              <div className="relative flex h-[60px] w-[60px] items-center justify-center overflow-hidden rounded-full">
+              <div className="relative flex h-[60px] w-[60px] flex-shrink-0 items-center justify-center overflow-hidden rounded-full">
                 <Image
                   src={"/assets/unknown.png"}
                   width={60}
@@ -113,17 +114,28 @@ export default function WalletAssets({ appWallet }: { appWallet: Wallet }) {
             )}
             <LinkCardanoscan
               url={`tokenPolicy/${policyId}`}
-              className="ml-auto gap-1"
+              className="min-w-0 gap-1"
             >
-              <div className="flex flex-row items-center gap-1">
-                <h3 className="text-lg font-bold">{name}</h3>
-                <ArrowUpRight className="h-4 w-4" />
+              <div className="flex min-w-0 flex-row items-center gap-1">
+                <h3 className="truncate text-lg font-bold" title={name}>
+                  {truncateTokenSymbol(name)}
+                </h3>
+                <ArrowUpRight className="h-4 w-4 flex-shrink-0" />
               </div>
             </LinkCardanoscan>
           </div>
-          <div className="flex flex-row gap-1">
-            <p className="font-bold">{quantity}</p>
-            <p className="text-gray-400">${ticker}</p>
+          <div className="flex flex-shrink-0 flex-row items-baseline gap-1">
+            <p className="font-bold tabular-nums">
+              {numberWithCommas(quantity)}
+            </p>
+            {ticker && (
+              <p
+                className="max-w-[80px] truncate text-gray-400"
+                title={`$${ticker}`}
+              >
+                ${ticker}
+              </p>
+            )}
           </div>
         </div>
       );


### PR DESCRIPTION
The Assets card clipped token rows on the right (the cut-off "↗1 $S…" for `$drep.collective`).

**Root cause** (verified): the token row's flex row + left group lacked `min-w-0`, so the name/quantity/ticker couldn't shrink below their intrinsic width, and none were truncated — long names/quantities pushed the value column past the card edge. (ADA renders fine because its name is the hardcoded "ADA".)

## Fix — `wallet-assets.tsx` token row
- `min-w-0` on the row, `flex-1 min-w-0` on the left group (the actual fix — a flex child can't shrink below content width without `min-w-0`).
- `flex-shrink-0` on both 60px avatar wrappers (so the image doesn't compress instead of the text).
- name `<h3>` truncates with a `title` tooltip and is bounded via `truncateTokenSymbol` for the raw-hex fallback; removed `ml-auto`.
- value block `flex-shrink-0`; quantity via `numberWithCommas` + `tabular-nums`; ticker truncates `max-w-[80px]` with a `title`.

Full name still reachable via tooltip + the Cardanoscan token link (deep-link uses the policyId, unaffected).

## Verify
- Chrome MCP 390px + desktop (card ≈ 1/3 grid width) with a long-named/large-balance token: name ellipsizes, value/ticker pinned inside the right edge, avatar stays round.
- `tsc` clean.

Part of the governance/assets UX pass (map→design→judge workflow). Sibling PRs: ballot voting controls + gov-card colored chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)