### PR TITLE
Reliable IPFS, rationale drafting/caching, and ballot CSV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ JWT_SECRET="your-jwt-secret-minimum-32-characters-long"
 # Get your JWT token from https://app.pinata.cloud/
 PINATA_JWT="your-pinata-jwt-token"
 
+# Optional: dedicated Pinata IPFS gateway origin (e.g. https://<id>.mypinata.cloud).
+# IPFS reads resolve through /api/ipfs/resolve, which tries this gateway first
+# (our pinned content) before falling back to public gateways, and new uploads
+# return a URL on this gateway instead of the frequently-504ing public ipfs.io.
+# NEXT_PUBLIC_PINATA_GATEWAY_URL="https://your-gateway.mypinata.cloud"
+
 # GitHub Personal Access Token
 # Create one at https://github.com/settings/tokens
 # GITHUB_TOKEN="your-github-token" (Optional - for GitHub issue creation)

--- a/src/components/pages/wallet/governance/ballot/BallotCsv.tsx
+++ b/src/components/pages/wallet/governance/ballot/BallotCsv.tsx
@@ -1,0 +1,235 @@
+import { useCallback } from "react";
+import Papa from "papaparse";
+import { useDropzone } from "react-dropzone";
+import { Download, Upload, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { api } from "@/utils/api";
+import { toast } from "@/hooks/use-toast";
+import type { BallotType } from "./ballot";
+
+/**
+ * CSV import/export for a ballot. The CSV columns are:
+ *   proposal_id, title, vote, comment, anchor_url, anchor_hash
+ *
+ * Export uses Papa.unparse so commas / newlines inside rationale comments are
+ * quoted correctly. Import merges by `proposal_id`: existing proposals are
+ * updated in place, unseen ones are appended — proposals already in the ballot
+ * but absent from the CSV are preserved. For an existing proposal a blank CSV
+ * cell leaves that field unchanged (including the vote), so a CSV that only
+ * fills in, say, anchor_url won't reset votes. Newly-appended proposals default
+ * to an Abstain vote when their vote cell is blank.
+ */
+
+const CSV_HEADERS = [
+  "proposal_id",
+  "title",
+  "vote",
+  "comment",
+  "anchor_url",
+  "anchor_hash",
+] as const;
+
+function normalizeVote(value: string | undefined): "Yes" | "No" | "Abstain" {
+  const s = (value ?? "").trim().toLowerCase();
+  if (s === "yes" || s === "y") return "Yes";
+  if (s === "no" || s === "n") return "No";
+  return "Abstain";
+}
+
+function sanitizeFilename(name: string): string {
+  const cleaned = name.replace(/[^a-z0-9-_]+/gi, "-").replace(/^-+|-+$/g, "").toLowerCase();
+  return cleaned || "ballot";
+}
+
+export default function BallotCsv({
+  ballot,
+  ballotId,
+  onImported,
+}: {
+  ballot: BallotType;
+  ballotId: string;
+  onImported?: () => void | Promise<unknown>;
+}) {
+  const updateBallot = api.ballot.updateBallot.useMutation();
+
+  const handleExport = useCallback(() => {
+    const rows = ballot.items.map((proposalId, i) => ({
+      proposal_id: proposalId ?? "",
+      title: ballot.itemDescriptions?.[i] ?? "",
+      vote: ballot.choices?.[i] ?? "Abstain",
+      comment: ballot.rationaleComments?.[i] ?? "",
+      anchor_url: ballot.anchorUrls?.[i] ?? "",
+      anchor_hash: ballot.anchorHashes?.[i] ?? "",
+    }));
+    const csv = Papa.unparse({ fields: [...CSV_HEADERS], data: rows });
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.setAttribute("href", url);
+    link.setAttribute("download", `${sanitizeFilename(ballot.description ?? "ballot")}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [ballot]);
+
+  const onDrop = useCallback(
+    (files: File[]) => {
+      const file = files[0];
+      if (!file) return;
+      Papa.parse<Record<string, string>>(file, {
+        header: true,
+        skipEmptyLines: true,
+        transformHeader: (h) => h.trim().toLowerCase(),
+        complete: (results) => {
+          void (async () => {
+            try {
+              const items = [...ballot.items];
+              const itemDescriptions = [...(ballot.itemDescriptions ?? [])];
+              const choices = [...(ballot.choices ?? [])];
+              const anchorUrls = [...(ballot.anchorUrls ?? [])];
+              const anchorHashes = [...(ballot.anchorHashes ?? [])];
+              const rationaleComments = [...(ballot.rationaleComments ?? [])];
+
+              let added = 0;
+              let updated = 0;
+              let skipped = 0;
+
+              for (const row of results.data) {
+                const proposalId = (row.proposal_id ?? row.proposalid ?? "").trim();
+                if (!proposalId) {
+                  skipped++;
+                  continue;
+                }
+                const title = (row.title ?? "").trim();
+                const voteRaw = (row.vote ?? "").trim();
+                const comment = (row.comment ?? "").trim();
+                const anchorUrl = (row.anchor_url ?? row.anchorurl ?? "").trim();
+                const anchorHash = (row.anchor_hash ?? row.anchorhash ?? "").trim();
+
+                const idx = items.indexOf(proposalId);
+                if (idx >= 0) {
+                  // Update in place; a blank cell leaves the existing value intact,
+                  // including the vote (so anchor-only CSVs don't reset choices).
+                  if (title) itemDescriptions[idx] = title;
+                  if (voteRaw) choices[idx] = normalizeVote(voteRaw);
+                  if (comment) rationaleComments[idx] = comment;
+                  if (anchorUrl) anchorUrls[idx] = anchorUrl;
+                  if (anchorHash) anchorHashes[idx] = anchorHash;
+                  updated++;
+                } else {
+                  // New proposal: a blank vote cell defaults to Abstain.
+                  items.push(proposalId);
+                  itemDescriptions.push(title);
+                  choices.push(normalizeVote(voteRaw));
+                  rationaleComments.push(comment);
+                  anchorUrls.push(anchorUrl);
+                  anchorHashes.push(anchorHash);
+                  added++;
+                }
+              }
+
+              if (added === 0 && updated === 0) {
+                toast({
+                  title: "Nothing imported",
+                  description: "No rows with a proposal_id were found. Check the CSV header.",
+                  variant: "destructive",
+                });
+                return;
+              }
+
+              await updateBallot.mutateAsync({
+                ballotId,
+                items,
+                itemDescriptions,
+                choices,
+                anchorUrls,
+                anchorHashes,
+                rationaleComments,
+                type: ballot.type,
+              });
+              await onImported?.();
+              toast({
+                title: "Ballot imported",
+                description: `${added} added, ${updated} updated${skipped ? `, ${skipped} skipped` : ""}.`,
+              });
+            } catch (error) {
+              toast({
+                title: "Import failed",
+                description: error instanceof Error ? error.message : "Could not import CSV.",
+                variant: "destructive",
+              });
+            }
+          })();
+        },
+        error: (error) => {
+          toast({
+            title: "Parse error",
+            description: error.message,
+            variant: "destructive",
+          });
+        },
+      });
+    },
+    [ballot, ballotId, updateBallot, onImported],
+  );
+
+  const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
+    onDrop,
+    accept: { "text/csv": [".csv"] },
+    multiple: false,
+    noClick: true,
+    noKeyboard: true,
+  });
+
+  return (
+    <div className="mt-4 space-y-2">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <p className="text-xs font-medium text-gray-600 dark:text-gray-400">
+          Import / export ballot as CSV
+        </p>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={open}
+            disabled={updateBallot.isPending}
+          >
+            {updateBallot.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Upload className="h-3.5 w-3.5" />
+            )}
+            Import CSV
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={handleExport}
+            disabled={ballot.items.length === 0}
+          >
+            <Download className="h-3.5 w-3.5" />
+            Export CSV
+          </Button>
+        </div>
+      </div>
+      <div
+        {...getRootProps()}
+        className={`flex items-center justify-center rounded-md border-2 border-dashed px-3 py-2 text-center text-xs transition-colors ${
+          isDragActive
+            ? "border-blue-400 bg-blue-50/60 dark:border-blue-500 dark:bg-blue-950/20"
+            : "border-muted-foreground/30 hover:bg-muted/40"
+        }`}
+      >
+        <input {...getInputProps()} />
+        <span className="text-muted-foreground">
+          {isDragActive
+            ? "Drop the CSV here…"
+            : "Drag & drop a CSV, or use Import. Columns: proposal_id, title, vote, comment, anchor_url, anchor_hash"}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/wallet/governance/ballot/ballot.tsx
+++ b/src/components/pages/wallet/governance/ballot/ballot.tsx
@@ -36,6 +36,8 @@ import { hashDrepAnchor } from "@meshsdk/core";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { parseProposalId } from "@/lib/governance";
+import { fetchIpfsJson } from "@/lib/ipfs";
+import BallotCsv from "./BallotCsv";
 
 const GovAction = 1;
 
@@ -880,12 +882,26 @@ export default function BallotCard({
                   <Trash2 className="h-4 w-4 text-red-600 dark:text-red-400" />
                 </Button>
               </div>
+
+              {/* CSV import / export */}
+              <BallotCsv
+                ballot={selectedBallot}
+                ballotId={selectedBallot.id}
+                onImported={() => getBallots.refetch()}
+              />
             </>
           ) : (
             <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
               <VoteIcon className="h-16 w-16 text-gray-300 dark:text-gray-600 mb-4" />
               <p className="text-base font-medium text-gray-700 dark:text-gray-300 mb-2">No proposals in this ballot</p>
-              <p className="text-sm text-gray-500 dark:text-gray-500">Add proposals to start voting</p>
+              <p className="text-sm text-gray-500 dark:text-gray-500">Add proposals manually or import a CSV to start voting</p>
+              <div className="mt-4 w-full max-w-xl text-left">
+                <BallotCsv
+                  ballot={selectedBallot}
+                  ballotId={selectedBallot.id}
+                  onImported={() => getBallots.refetch()}
+                />
+              </div>
               <div className="mt-4 flex items-center gap-2">
                 <Button
                   variant="outline"
@@ -994,6 +1010,7 @@ function ProposalRationaleEditor({
   onStateChange,
   onUpload,
   onLoadFromUrl,
+  onPersistComment,
   loading,
 }: {
   idx: number;
@@ -1001,6 +1018,7 @@ function ProposalRationaleEditor({
   onStateChange: (updates: Partial<{ json: string; url: string; hash: string; loading: boolean; comment?: string }>) => void;
   onUpload: () => void;
   onLoadFromUrl: (url?: string) => void;
+  onPersistComment?: () => void;
   loading: boolean;
 }) {
   const state = rationaleState || { json: "", url: "", hash: "", loading: false, comment: "" };
@@ -1091,9 +1109,13 @@ function ProposalRationaleEditor({
           <Textarea
             value={state.comment || ""}
             onChange={(e) => handleCommentChange(e.target.value)}
+            onBlur={() => onPersistComment?.()}
             placeholder="Enter your voting rationale comment..."
             className="min-h-[80px] text-xs"
           />
+          <p className="text-[11px] text-gray-500 dark:text-gray-400">
+            Drafts save automatically; upload to IPFS to anchor the rationale on-chain.
+          </p>
         </div>
         <div className="space-y-2">
           <label className="text-xs font-medium text-gray-700 dark:text-gray-300">Rationale URL (optional)</label>
@@ -1168,6 +1190,7 @@ function BallotOverviewTable({
   const { toast } = useToast();
   const updateChoiceMutation = api.ballot.updateChoice.useMutation();
   const updateAnchorMutation = api.ballot.updateProposalAnchor.useMutation();
+  const updateRationaleMutation = api.ballot.updateProposalRationale.useMutation();
   const [updatingIdx, setUpdatingIdx] = React.useState<number | null>(null);
   const [expandedRationaleIdx, setExpandedRationaleIdx] = React.useState<number | null>(null);
   const [rationaleStates, setRationaleStates] = React.useState<Record<number, {
@@ -1177,7 +1200,15 @@ function BallotOverviewTable({
     loading: boolean;
     comment?: string;
   }>>({});
-  
+  // Tracks which anchor URL we've already auto-loaded per row, so a refetch that
+  // only changed an unrelated field (e.g. a vote choice) doesn't re-fetch every
+  // anchor or clobber in-progress edits.
+  const loadedAnchorsRef = React.useRef<Record<number, string>>({});
+  // Per-row seed identity (`proposalId anchorUrl`). When unchanged we keep
+  // the user's in-progress editor state; when it changes (proposal added/removed
+  // so indices shift, or the anchor changed) we reseed that row from ballot data.
+  const seedKeysRef = React.useRef<Record<number, string>>({});
+
   const {
     removingIdx,
     deleteProposalIdx,
@@ -1191,65 +1222,83 @@ function BallotOverviewTable({
     return hashDrepAnchor(jsonData as Record<string, unknown>);
   }, []);
 
-  // Initialize rationale states from ballot data and auto-load existing anchors
+  // Seed rationale states from ballot data and auto-load existing anchors. This
+  // re-runs whenever the ballot arrays change reference (e.g. after any refetch),
+  // so it MUST NOT blow away in-progress editor edits: rows whose anchor URL is
+  // unchanged keep their local state, and anchors already loaded aren't re-fetched.
   React.useEffect(() => {
-    const states: Record<number, { json: string; url: string; hash: string; loading: boolean; comment?: string }> = {};
-    const loadPromises: Promise<void>[] = [];
-    
+    const controller = new AbortController();
+
+    // Snapshot the previous seed keys before reassigning the ref below — the
+    // functional setState updater runs after this effect body, so it must read a
+    // captured copy, not seedKeysRef.current (which is overwritten by then).
+    const prevSeedKeys = seedKeysRef.current;
+    const nextSeedKeys: Record<number, string> = {};
+    ballot.items.forEach((itemId, idx) => {
+      nextSeedKeys[idx] = `${itemId ?? ""} ${ballot.anchorUrls?.[idx] || ""}`;
+    });
+
+    setRationaleStates((prev) => {
+      const next: typeof prev = {};
+      ballot.items.forEach((_, idx) => {
+        const anchorUrl = ballot.anchorUrls?.[idx] || "";
+        const anchorHash = ballot.anchorHashes?.[idx] || "";
+        const existing = prev[idx];
+        const reseed = !existing || prevSeedKeys[idx] !== nextSeedKeys[idx];
+        if (reseed) {
+          // New row, shifted proposal, or changed anchor: seed fresh from ballot.
+          next[idx] = {
+            json: "",
+            url: anchorUrl,
+            hash: anchorHash,
+            loading: !!anchorUrl.trim(),
+            comment: anchorUrl.trim() ? "" : ballot.rationaleComments?.[idx] || "",
+          };
+        } else {
+          // Same proposal + anchor: keep the user's in-progress edits, refresh hash.
+          next[idx] = { ...existing, hash: anchorHash || existing.hash };
+        }
+      });
+      return next;
+    });
+    seedKeysRef.current = nextSeedKeys;
+
+    // Auto-load anchors we haven't already fetched for the current URL.
     ballot.items.forEach((_, idx) => {
       const anchorUrl = ballot.anchorUrls?.[idx] || "";
-      const draftComment = anchorUrl.trim() ? "" : ballot.rationaleComments?.[idx] || "";
-      states[idx] = {
-        json: "",
-        url: anchorUrl,
-        hash: ballot.anchorHashes?.[idx] || "",
-        loading: !!anchorUrl.trim(), // Set loading if we have a URL to fetch
-        comment: draftComment,
-      };
-      
-      // Auto-load rationale if anchor URL exists
-      if (anchorUrl.trim()) {
-        const loadPromise = fetch(anchorUrl)
-          .then(async (res) => {
-            if (!res.ok) throw new Error("Failed to fetch rationale");
-            const data = await res.json();
-            const hash = computeHashFromJson(data);
-            const comment = data?.body?.comment || "";
-            setRationaleStates(prev => ({ 
-              ...prev, 
-              [idx]: { 
-                json: JSON.stringify(data, null, 2),
-                url: anchorUrl,
-                hash,
-                comment,
-                loading: false 
-              } 
-            }));
-          })
-          .catch(() => {
-            // Silently fail - user can manually reload if needed
-            setRationaleStates(prev => {
-              const currentState = prev[idx] || states[idx];
-              return {
-                ...prev,
-                [idx]: {
-                  json: currentState?.json || "",
-                  url: currentState?.url || "",
-                  hash: currentState?.hash || "",
-                  comment: currentState?.comment || "",
-                  loading: false
-                }
-              };
-            });
-          });
-        loadPromises.push(loadPromise);
+      if (!anchorUrl.trim()) {
+        delete loadedAnchorsRef.current[idx];
+        return;
       }
+      if (loadedAnchorsRef.current[idx] === anchorUrl) return; // already loaded
+      fetchIpfsJson<{ body?: { comment?: string } }>(anchorUrl, controller.signal)
+        .then((data) => {
+          if (controller.signal.aborted) return;
+          const hash = computeHashFromJson(data);
+          const comment = data?.body?.comment || "";
+          loadedAnchorsRef.current[idx] = anchorUrl;
+          setRationaleStates((prev) => ({
+            ...prev,
+            [idx]: { json: JSON.stringify(data, null, 2), url: anchorUrl, hash, comment, loading: false },
+          }));
+        })
+        .catch(() => {
+          if (controller.signal.aborted) return;
+          // Leave the (possibly stale) anchor unmarked so a later retry can reload.
+          setRationaleStates((prev) => ({
+            ...prev,
+            [idx]: {
+              json: prev[idx]?.json || "",
+              url: prev[idx]?.url || anchorUrl,
+              hash: prev[idx]?.hash || "",
+              comment: prev[idx]?.comment || "",
+              loading: false,
+            },
+          }));
+        });
     });
-    
-    // Set initial states first
-    setRationaleStates(states);
-    
-    // Auto-load will happen asynchronously via the promises
+
+    return () => controller.abort();
   }, [ballot.items, ballot.anchorUrls, ballot.anchorHashes, ballot.rationaleComments, computeHashFromJson]);
 
   const getChoiceColor = (choice: string) => {
@@ -1299,6 +1348,23 @@ function BallotOverviewTable({
     }
   }, [ballotId, updateChoiceMutation, refetchBallots, onBallotChanged, toast]);
 
+  // Persist the draft rationale comment to the DB so it survives reloads and is
+  // available for review in the pending transaction (cached, no IPFS round-trip).
+  const persistRationaleComment = useCallback(async (idx: number, override?: string) => {
+    const comment = (override ?? rationaleStates[idx]?.comment ?? "").trim();
+    if (comment === (ballot.rationaleComments?.[idx] ?? "").trim()) return; // no change
+    try {
+      await updateRationaleMutation.mutateAsync({
+        ballotId,
+        index: idx,
+        rationaleComment: comment,
+      });
+      await refetchBallots();
+    } catch {
+      // Non-fatal: drafting is best-effort; the user can re-save or upload.
+    }
+  }, [rationaleStates, ballot.rationaleComments, ballotId, updateRationaleMutation, refetchBallots]);
+
   const uploadRationaleToIpfs = useCallback(async (idx: number) => {
     const state = rationaleStates[idx];
     if (!state?.json.trim()) {
@@ -1344,6 +1410,19 @@ function BallotOverviewTable({
         anchorUrl: res.url,
         anchorHash: hash,
       });
+      // Cache the rationale comment in the DB alongside the anchor so the
+      // pending-transaction review can render it without an IPFS round-trip.
+      const cachedComment =
+        (state.comment ??
+          (parsed as { body?: { comment?: string } })?.body?.comment ??
+          "").trim();
+      if (cachedComment) {
+        await updateRationaleMutation.mutateAsync({
+          ballotId,
+          index: idx,
+          rationaleComment: cachedComment,
+        });
+      }
       await refetchBallots();
       toast({
         title: "Rationale uploaded",
@@ -1357,7 +1436,7 @@ function BallotOverviewTable({
         variant: "destructive",
       });
     }
-  }, [rationaleStates, computeHashFromJson, ballotId, updateAnchorMutation, refetchBallots, toast]);
+  }, [rationaleStates, computeHashFromJson, ballotId, updateAnchorMutation, updateRationaleMutation, refetchBallots, toast]);
 
   const loadRationaleFromUrl = useCallback(async (idx: number, overrideUrl?: string) => {
     const state = rationaleStates[idx];
@@ -1372,22 +1451,22 @@ function BallotOverviewTable({
     }
     setRationaleStates(prev => ({ ...prev, [idx]: { ...prev[idx]!, loading: true } }));
     try {
-      const res = await fetch(targetUrl);
-      if (!res.ok) throw new Error("Failed to fetch rationale");
-      const data = await res.json();
+      const data = await fetchIpfsJson<{ body?: { comment?: string } }>(targetUrl);
       const hash = computeHashFromJson(data);
       // Extract comment from loaded JSON-LD if present
       const comment = data?.body?.comment || "";
-      setRationaleStates(prev => ({ 
-        ...prev, 
-        [idx]: { 
-          ...prev[idx]!, 
+      // Mark loaded so the auto-load effect doesn't redundantly re-fetch this URL.
+      loadedAnchorsRef.current[idx] = targetUrl;
+      setRationaleStates(prev => ({
+        ...prev,
+        [idx]: {
+          ...prev[idx]!,
           json: JSON.stringify(data, null, 2),
           url: targetUrl,
           hash,
           comment,
-          loading: false 
-        } 
+          loading: false
+        }
       }));
       await updateAnchorMutation.mutateAsync({
         ballotId,
@@ -1540,6 +1619,7 @@ function BallotOverviewTable({
                             onStateChange={(updates) => setRationaleStates(prev => ({ ...prev, [idx]: { ...prev[idx]!, ...updates } }))}
                             onUpload={() => uploadRationaleToIpfs(idx)}
                             onLoadFromUrl={(url) => loadRationaleFromUrl(idx, url)}
+                            onPersistComment={() => persistRationaleComment(idx)}
                             loading={rationaleStates[idx]?.loading || false}
                           />
                         </td>
@@ -1598,6 +1678,7 @@ function BallotOverviewTable({
                       onStateChange={(updates) => setRationaleStates(prev => ({ ...prev, [idx]: { ...prev[idx]!, ...updates } }))}
                       onUpload={() => uploadRationaleToIpfs(idx)}
                       onLoadFromUrl={(url) => loadRationaleFromUrl(idx, url)}
+                      onPersistComment={() => persistRationaleComment(idx)}
                       loading={rationaleStates[idx]?.loading || false}
                     />
                   </div>

--- a/src/components/pages/wallet/transactions/transaction-card.tsx
+++ b/src/components/pages/wallet/transactions/transaction-card.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import {
   checkSignature,
@@ -24,7 +24,8 @@ import { Transaction } from "@prisma/client";
 
 import { TooltipProvider, TooltipTrigger } from "@radix-ui/react-tooltip";
 
-import { Check, Loader, MoreVertical, X, User, Copy, CheckCircle2, XCircle, MinusCircle, Vote, ChevronDown, ChevronUp, Award, UserMinus, UserPlus, UserCog } from "lucide-react";
+import { Check, Loader, MoreVertical, X, User, Copy, CheckCircle2, XCircle, MinusCircle, Vote, ChevronDown, ChevronUp, Award, UserMinus, UserPlus, UserCog, FileText, ExternalLink } from "lucide-react";
+import { fetchIpfsJson, extractCidPath, ipfsGatewayUrl } from "@/lib/ipfs";
 import { ToastAction } from "@/components/ui/toast";
 import { Tooltip, TooltipContent } from "@/components/ui/tooltip";
 import DiscordIcon from "@/components/common/discordIcon";
@@ -61,6 +62,143 @@ import {
   shouldSubmitMultisigTx,
   submitTxWithScriptRecovery,
 } from "@/utils/txSignUtils";
+/**
+ * Renders the voting rationale for a single vote in a pending transaction.
+ * Prefers the DB-cached comment (saved when the ballot rationale was drafted /
+ * uploaded) so review needs no network call; falls back to resolving the IPFS
+ * anchor through /api/ipfs/resolve when there's no cache.
+ */
+function VoteRationale({
+  walletId,
+  anchorUrl,
+  anchorHash,
+}: {
+  walletId: string;
+  anchorUrl?: string;
+  anchorHash?: string;
+}) {
+  const { data: ballots } = api.ballot.getByWallet.useQuery(
+    { walletId },
+    { enabled: !!walletId },
+  );
+
+  const cachedComment = useMemo(() => {
+    if (!ballots) return undefined;
+    for (const b of ballots) {
+      const urls = b.anchorUrls ?? [];
+      const hashes = b.anchorHashes ?? [];
+      const comments = b.rationaleComments ?? [];
+      const len = Math.max(urls.length, hashes.length, comments.length);
+      for (let i = 0; i < len; i++) {
+        const urlMatch = !!anchorUrl && !!urls[i] && urls[i] === anchorUrl;
+        const hashMatch = !!anchorHash && !!hashes[i] && hashes[i] === anchorHash;
+        if (urlMatch || hashMatch) {
+          const c = comments[i]?.trim();
+          if (c) return c;
+        }
+      }
+    }
+    return undefined;
+  }, [ballots, anchorUrl, anchorHash]);
+
+  const [open, setOpen] = useState(false);
+  const [fetched, setFetched] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!open || cachedComment || fetched !== null || !anchorUrl) return;
+    let aborted = false;
+    setLoading(true);
+    setError(false);
+    fetchIpfsJson<{ body?: { comment?: string } }>(anchorUrl)
+      .then((data) => {
+        if (!aborted) setFetched(data?.body?.comment?.trim() ?? "");
+      })
+      .catch(() => {
+        if (!aborted) setError(true);
+      })
+      .finally(() => {
+        if (!aborted) setLoading(false);
+      });
+    return () => {
+      aborted = true;
+    };
+  }, [open, cachedComment, fetched, anchorUrl]);
+
+  // Nothing to show: no on-chain anchor and no cached draft.
+  if (!anchorUrl && !cachedComment) return null;
+
+  const comment = cachedComment ?? (fetched || undefined);
+  // Link to the canonical document: a direct http(s) anchor as-is, otherwise the
+  // IPFS gateway URL for the CID (a human-openable page, not our JSON proxy).
+  const cidPath = anchorUrl ? extractCidPath(anchorUrl) : null;
+  const href = anchorUrl
+    ? anchorUrl.startsWith("http")
+      ? anchorUrl
+      : cidPath
+        ? ipfsGatewayUrl(cidPath)
+        : undefined
+    : undefined;
+
+  return (
+    <div className="pl-5">
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <div className="flex items-center gap-2">
+          <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
+            <FileText className="h-3 w-3" />
+            <span className="font-medium">Rationale</span>
+            {cachedComment && (
+              <Badge
+                variant="outline"
+                className="px-1 py-0 text-[9px] uppercase tracking-wide text-muted-foreground border-border/50"
+              >
+                cached
+              </Badge>
+            )}
+            {open ? (
+              <ChevronUp className="h-3 w-3" />
+            ) : (
+              <ChevronDown className="h-3 w-3" />
+            )}
+          </CollapsibleTrigger>
+          {href && (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ExternalLink className="h-3 w-3" />
+              <span>source</span>
+            </a>
+          )}
+        </div>
+        <CollapsibleContent className="mt-1.5">
+          {comment ? (
+            <p className="whitespace-pre-wrap rounded-md border border-border/50 bg-muted/30 p-2 text-xs text-foreground/90">
+              {comment}
+            </p>
+          ) : loading ? (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Loader className="h-3 w-3 animate-spin" />
+              <span>Loading rationale…</span>
+            </div>
+          ) : error ? (
+            <p className="text-xs text-muted-foreground">
+              Could not load rationale from IPFS.
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              No rationale comment attached.
+            </p>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}
+
 export default function TransactionCard({
   walletId,
   transaction,
@@ -768,6 +906,9 @@ export default function TransactionCard({
                     const govActionId = vote.vote?.govActionId;
                     const govActionHash = govActionId?.txHash || "Unknown";
                     const govActionIndex = govActionId?.txIndex ?? "Unknown";
+                    const anchor = vote.vote?.votingProcedure?.anchor;
+                    const anchorUrl: string | undefined = anchor?.anchorUrl;
+                    const anchorHash: string | undefined = anchor?.anchorDataHash;
 
                     return (
                       <div key={index} className="space-y-2">
@@ -791,6 +932,11 @@ export default function TransactionCard({
                             </span>
                           </div>
                         </div>
+                        <VoteRationale
+                          walletId={walletId}
+                          anchorUrl={anchorUrl}
+                          anchorHash={anchorHash}
+                        />
                       </div>
                     );
                   })}

--- a/src/env.js
+++ b/src/env.js
@@ -74,6 +74,15 @@ export const env = createEnv({
     NEXT_PUBLIC_UMAMI_WEBSITE_ID: z.string().optional(),
     /** Umami script URL; default is Umami Cloud. Use your self-hosted URL if needed. */
     NEXT_PUBLIC_UMAMI_SCRIPT_URL: z.string().url().optional(),
+    /**
+     * Dedicated Pinata IPFS gateway origin (e.g. https://<id>.mypinata.cloud
+     * or a bare host like <id>.mypinata.cloud). IPFS reads resolve through
+     * /api/ipfs/resolve, which tries this gateway first (our pinned content)
+     * before falling back to public gateways, and new uploads return a URL on
+     * this gateway instead of the flaky ipfs.io. A missing scheme is normalised
+     * to https:// in code, so a bare hostname is accepted here.
+     */
+    NEXT_PUBLIC_PINATA_GATEWAY_URL: z.string().optional(),
   },
 
   /**
@@ -95,6 +104,7 @@ export const env = createEnv({
     NEXT_PUBLIC_UTXOS_PROJECT_ID: process.env.NEXT_PUBLIC_UTXOS_PROJECT_ID,
     NEXT_PUBLIC_NETWORK_ID: process.env.NEXT_PUBLIC_NETWORK_ID ?? "0",
     NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+    NEXT_PUBLIC_PINATA_GATEWAY_URL: process.env.NEXT_PUBLIC_PINATA_GATEWAY_URL,
     NEXT_PUBLIC_UMAMI_WEBSITE_ID: process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID,
     NEXT_PUBLIC_UMAMI_SCRIPT_URL: process.env.NEXT_PUBLIC_UMAMI_SCRIPT_URL,
     PINATA_JWT: process.env.PINATA_JWT,

--- a/src/lib/ipfs.ts
+++ b/src/lib/ipfs.ts
@@ -1,0 +1,137 @@
+import { env } from "@/env";
+
+/**
+ * IPFS gateway helpers.
+ *
+ * The public `ipfs.io` gateway frequently returns 504s, so reads go through the
+ * server-side `/api/ipfs/resolve` proxy which tries several gateways (our pinned
+ * Pinata gateway first) with a short per-gateway timeout. Uploads return a
+ * reliable Pinata gateway URL instead of `ipfs.io`.
+ */
+
+/** Pinata gateway base (scheme-qualified, no trailing slash, no `/ipfs`), or null. */
+function pinataGateway(): string | null {
+  let raw = env.NEXT_PUBLIC_PINATA_GATEWAY_URL?.trim();
+  if (!raw) return null;
+  // Accept a bare host (e.g. "id.mypinata.cloud") by normalising the scheme.
+  if (!/^https?:\/\//i.test(raw)) raw = `https://${raw}`;
+  return raw.replace(/\/+$/, "").replace(/\/ipfs$/i, "");
+}
+
+/**
+ * Extract the `cid[/path]` portion from a CID, an `ipfs://…` URL, or any
+ * `…/ipfs/<cid>` gateway URL. Returns null if it doesn't look like IPFS.
+ */
+export function extractCidPath(input: string | undefined | null): string | null {
+  if (!input) return null;
+  let s = input.trim();
+  if (!s) return null;
+  if (s.startsWith("ipfs://")) s = s.replace(/^ipfs:\/\/(ipfs\/)?/i, "");
+  const m = s.match(/\/ipfs\/(.+)$/i);
+  if (m?.[1]) s = m[1];
+  s = s.split(/[?#]/)[0]!.replace(/^\/+/, "");
+  if (!s || s.includes("..")) return null;
+  const cid = s.split("/")[0]!;
+  // CID-ish: base58 v0 (Qm…), base32 v1 (b…), or another long alphanumeric token.
+  if (!/^[A-Za-z0-9]{20,}$/.test(cid)) return null;
+  return s;
+}
+
+/** Ordered gateway bases (most reliable for our pinned content first). */
+export function ipfsGatewayBases(): string[] {
+  const bases: string[] = [];
+  const pinata = pinataGateway();
+  if (pinata) bases.push(`${pinata}/ipfs/`);
+  bases.push("https://gateway.pinata.cloud/ipfs/");
+  bases.push("https://ipfs.io/ipfs/");
+  bases.push("https://dweb.link/ipfs/");
+  bases.push("https://w3s.link/ipfs/");
+  return [...new Set(bases)];
+}
+
+/** A reliable gateway URL for a freshly-pinned CID (used for on-chain anchors). */
+export function ipfsGatewayUrl(cid: string): string {
+  const pinata = pinataGateway();
+  const base = pinata ? `${pinata}/ipfs/` : "https://gateway.pinata.cloud/ipfs/";
+  return `${base}${cid}`;
+}
+
+/** App route that resolves an anchor (cid / ipfs:// / gateway url) server-side. */
+export function ipfsResolveUrl(anchor: string): string {
+  return `/api/ipfs/resolve?url=${encodeURIComponent(anchor)}`;
+}
+
+/** Hard backstop so a hung gateway can't leave a request pending forever. The
+ * resolver itself tries up to 5 gateways at 6s each, so this sits above that. */
+const FETCH_TIMEOUT_MS = 35000;
+
+/**
+ * Derive an AbortSignal that fires when either the caller's signal aborts or a
+ * timeout elapses. Returns a cleanup to clear the timer / detach the listener.
+ */
+function timeoutSignal(
+  signal: AbortSignal | undefined,
+  ms: number,
+): { signal: AbortSignal; cleanup: () => void } {
+  const ctrl = new AbortController();
+  const onAbort = () => ctrl.abort();
+  if (signal) {
+    if (signal.aborted) ctrl.abort();
+    else signal.addEventListener("abort", onAbort, { once: true });
+  }
+  const timer = setTimeout(() => ctrl.abort(), ms);
+  return {
+    signal: ctrl.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      if (signal) signal.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
+/**
+ * Fetch + parse JSON from an IPFS anchor. IPFS references go through the resolver
+ * proxy (multi-gateway, server-side, no CORS); non-IPFS anchors are fetched
+ * directly but restricted to https — an `http://localhost/…` or
+ * `http://169.254.169.254/…` anchor (which a hostile co-signer could store) is
+ * rejected rather than auto-fetched from the browser.
+ */
+export async function fetchIpfsJson<T = unknown>(
+  anchor: string,
+  signal?: AbortSignal,
+): Promise<T> {
+  const isIpfs = extractCidPath(anchor) !== null;
+  let url: string;
+  if (isIpfs) {
+    url = ipfsResolveUrl(anchor);
+  } else {
+    let parsed: URL;
+    try {
+      parsed = new URL(anchor);
+    } catch {
+      throw new Error("Invalid rationale URL");
+    }
+    if (parsed.protocol !== "https:") {
+      throw new Error("Rationale URL must be https or an IPFS reference");
+    }
+    url = anchor;
+  }
+
+  const { signal: timed, cleanup } = timeoutSignal(signal, FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: timed });
+    if (!res.ok) {
+      let detail = "";
+      try {
+        const body = (await res.json()) as { error?: string };
+        if (body?.error) detail = `: ${body.error}`;
+      } catch {
+        // response body wasn't JSON; the status code alone will have to do
+      }
+      throw new Error(`Failed to fetch rationale (${res.status})${detail}`);
+    }
+    return (await res.json()) as T;
+  } finally {
+    cleanup();
+  }
+}

--- a/src/pages/api/ipfs/resolve.ts
+++ b/src/pages/api/ipfs/resolve.ts
@@ -1,0 +1,125 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { extractCidPath, ipfsGatewayBases } from "@/lib/ipfs";
+
+/**
+ * Resolve an IPFS reference (CID, `ipfs://…`, or any `…/ipfs/<cid>` URL) by
+ * trying several gateways server-side with a short per-gateway timeout, and
+ * return the first success. This shields the browser from the frequent `ipfs.io`
+ * 504s/CORS issues. SSRF-safe: every request starts at a fixed, known gateway,
+ * only the (validated) CID path is caller-influenced, and redirects are only
+ * followed to other known gateway hosts — never to an arbitrary/internal host.
+ */
+const PER_GATEWAY_TIMEOUT_MS = 6000;
+const MAX_BYTES = 2 * 1024 * 1024; // rationale/metadata JSON is tiny
+const MAX_REDIRECTS = 3;
+
+/** Hostnames the proxy is allowed to talk to (gateway hosts + subdomain forms). */
+function allowedGatewayHosts(): Set<string> {
+  const hosts = new Set<string>();
+  for (const base of ipfsGatewayBases()) {
+    try {
+      hosts.add(new URL(base).hostname.toLowerCase());
+    } catch {
+      // ignore malformed base
+    }
+  }
+  return hosts;
+}
+
+/**
+ * Some gateways (dweb.link, w3s.link, dedicated Pinata gateways) redirect the
+ * path form to a `<cid>.ipfs.<gateway>` subdomain. Allow those, plus any exact
+ * gateway host, but nothing else — this is the SSRF guard on redirect targets.
+ */
+function hostIsAllowed(host: string, allowed: Set<string>): boolean {
+  const h = host.toLowerCase();
+  if (allowed.has(h)) return true;
+  for (const base of allowed) {
+    if (h.endsWith(`.ipfs.${base}`) || h.endsWith(`.ipns.${base}`)) return true;
+  }
+  return false;
+}
+
+/**
+ * Fetch `startUrl`, following redirects manually and only to allowed gateway
+ * hosts over http(s). Returns the final non-redirect Response, or null if a
+ * redirect points somewhere disallowed or the hop limit is exceeded.
+ */
+async function fetchGuarded(
+  startUrl: string,
+  allowed: Set<string>,
+  signal: AbortSignal,
+): Promise<Response | null> {
+  let url = startUrl;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const res = await fetch(url, {
+      signal,
+      redirect: "manual",
+      headers: { Accept: "application/json, */*", "user-agent": "Mozilla/5.0" },
+    });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get("location");
+      if (!location) return null;
+      let nextUrl: URL;
+      try {
+        nextUrl = new URL(location, url);
+      } catch {
+        return null;
+      }
+      if (nextUrl.protocol !== "https:" && nextUrl.protocol !== "http:") return null;
+      if (!hostIsAllowed(nextUrl.hostname, allowed)) return null; // SSRF guard
+      url = nextUrl.toString();
+      continue;
+    }
+    return res;
+  }
+  return null; // too many redirects
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const raw = (req.query.url ?? req.query.cid ?? "") as string;
+  const cidPath = extractCidPath(String(raw));
+  if (!cidPath) {
+    return res.status(400).json({ error: "Invalid or missing IPFS reference" });
+  }
+
+  const allowed = allowedGatewayHosts();
+
+  for (const base of ipfsGatewayBases()) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), PER_GATEWAY_TIMEOUT_MS);
+    try {
+      const upstream = await fetchGuarded(base + cidPath, allowed, controller.signal);
+      clearTimeout(timeout);
+      if (!upstream || !upstream.ok) continue;
+
+      const buf = Buffer.from(await upstream.arrayBuffer());
+      if (buf.byteLength > MAX_BYTES) {
+        return res.status(413).json({ error: "IPFS content too large" });
+      }
+      // The proxy only serves rationale/metadata JSON. Pin the content type and
+      // forbid MIME sniffing so a hostile gateway can't get HTML/JS executed.
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      res.setHeader(
+        "Cache-Control",
+        "public, s-maxage=86400, max-age=3600, stale-while-revalidate=604800",
+      );
+      return res.send(buf);
+    } catch {
+      clearTimeout(timeout);
+      // try the next gateway
+    }
+  }
+
+  return res
+    .status(504)
+    .json({ error: "All IPFS gateways failed to resolve the content" });
+}

--- a/src/pages/api/pinata-storage/image/put.ts
+++ b/src/pages/api/pinata-storage/image/put.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { env } from "@/env";
+import { ipfsGatewayUrl } from "@/lib/ipfs";
 import formidable, { Fields, Files, File } from "formidable";
 import fs from "fs";
 
@@ -114,9 +115,9 @@ export default async function handler(
     }
 
     const pinataData = (await pinataResponse.json()) as PinataResponse;
-    
-    // Construct IPFS gateway URL using public IPFS gateway
-    const ipfsUrl = `https://ipfs.io/ipfs/${pinataData.data.cid}`;
+
+    // Return a reliable gateway URL (dedicated Pinata gateway when configured).
+    const ipfsUrl = ipfsGatewayUrl(pinataData.data.cid);
 
     return res.status(200).json({ 
       url: ipfsUrl,

--- a/src/pages/api/pinata-storage/put.ts
+++ b/src/pages/api/pinata-storage/put.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { env } from "@/env";
+import { ipfsGatewayUrl } from "@/lib/ipfs";
 
 interface PinataResponse {
   data: {
@@ -59,9 +60,10 @@ export default async function handler(
     }
 
     const pinataData = (await pinataResponse.json()) as PinataResponse;
-    
-    // Construct IPFS gateway URL using public IPFS gateway
-    const ipfsUrl = `https://ipfs.io/ipfs/${pinataData.data.cid}`;
+
+    // Return a reliable gateway URL (dedicated Pinata gateway when configured,
+    // else the shared Pinata gateway) — not the flaky public ipfs.io.
+    const ipfsUrl = ipfsGatewayUrl(pinataData.data.cid);
 
     res.status(200).json({ 
       url: ipfsUrl,


### PR DESCRIPTION
## Summary

Fixes the flaky IPFS upload/download on the ballot voting UI, adds rationale **drafting** persisted to the DB, surfaces the rationale for **review in the pending transaction**, and adds ballot **CSV import/export** — the four asks from the "Manage Ballots" report (IPFS 504s loading rationale from `ipfs.io`).

### IPFS reliability
- New `src/lib/ipfs.ts` gateway helpers + **`/api/ipfs/resolve`**, a multi-gateway server proxy: tries the dedicated Pinata gateway first, then public fallbacks, 6 s per gateway, 2 MB cap, long-cached. Browser reads go through it instead of hitting the frequently-504ing `ipfs.io` directly (no CORS, no single-gateway failure).
- Uploads (`pinata-storage/put.ts`, `image/put.ts`) now return a **dedicated-gateway URL** via `ipfsGatewayUrl()` rather than a hardcoded `ipfs.io` URL.
- `NEXT_PUBLIC_PINATA_GATEWAY_URL` added to `src/env.js` (optional; accepts a bare host — scheme normalised in code). On-chain anchor hashes are unaffected (`hashDrepAnchor` hashes the JSON body, not the URL).

### Rationale drafting + DB cache
- Draft comments persist on blur via `updateProposalRationale`; uploading also caches the comment in the `Ballot` row. **No schema migration** — the existing parallel arrays already hold it.
- `transaction-card.tsx` gains a `VoteRationale` block per vote that prefers the DB-cached comment (no network) and falls back to the IPFS proxy, with a gateway "source" link.

### Ballot CSV
- New `BallotCsv.tsx` (papaparse + react-dropzone). Columns: `proposal_id,title,vote,comment,anchor_url,anchor_hash`. Import **merges by `proposal_id`** (blank cells preserve existing values; new rows default to Abstain); export is correctly quoted via `Papa.unparse`. Available on both the populated and empty-ballot views.

### Hardening (from an adversarial multi-agent review of this branch)
- `resolve.ts` follows redirects **manually and only to allow-listed gateway hosts** (SSRF guard incl. `*.ipfs.dweb.link`/`w3s.link` subdomain forms), and pins `Content-Type: application/json` + `nosniff`.
- `fetchIpfsJson` rejects non-`https` non-IPFS anchors (blocks `http://localhost`/`169.254.169.254` from a hostile co-signer's anchor) and adds a timeout backstop.
- The rationale auto-load effect now merges by `proposalId + anchor` so refetches (e.g. changing a vote) don't clobber in-progress edits, aborts in-flight fetches on cleanup, and de-dupes re-fetches.

## Verification
- `tsc --noEmit` clean; `next build --webpack` succeeds (`/api/ipfs/resolve` emitted as a function route).
- 14 review findings triaged: 12 fixed; 2 consciously deferred — the `updateBallot` full-overwrite vs. concurrent per-row-edit race (architectural; worst-case silent vote loss already removed by the blank-cell-preserve fix) and a low-severity O(n·m) cache lookup that tRPC already dedupes.

## Notes
- No DB migration. `.env`'s `NEXT_PUBLIC_PINATA_GATEWAY_URL` is already set (bare host) and now wired through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
