### PR TITLE
docs(agents): point to the vault as the source of specs/PRDs

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -2,6 +2,14 @@
 
 Project-specific context for AI coding agents. See also [.cursor/skills/multisig/SKILL.md](../.cursor/skills/multisig/SKILL.md) for the multisig Cursor skill.
 
+## Specs & PRDs
+
+Specs live in the vault, not this repo. The maintainer keeps a document-driven dev base (an Obsidian vault) where features are specified as **PRDs** before they are built; concept and entity notes there are the upstream source for data models and flows.
+
+- Before building a vault-specced feature, read its **PRD** (and the concept/entity notes it links) for scope, data model, and acceptance criteria. An entity note is the spec for its Prisma model.
+- Implementing PRs should **cite the PRD id** in the description (e.g. "Implements PRD-001"), so code stays traceable to the document that produced it.
+- The vault is the maintainer's local knowledge base; if you don't have access, ask for the relevant PRD's contents rather than guessing scope.
+
 ## Stack and layout
 
 - **Stack**: Next.js (Pages Router), TypeScript, tRPC, Prisma, PostgreSQL, Cardano (Mesh SDK). Auth: NextAuth (user) + JWT (API: wallet sign-in or bot keys).


### PR DESCRIPTION
Closes the doc↔code loop from the code side. Adds a **Specs & PRDs** section to `.agents/README.md`:

- Specs live in the maintainer's **document-driven vault**, not this repo — features are specified as **PRDs** before they're built; concept/entity notes are the upstream source for data models and flows.
- Before building a vault-specced feature, read its PRD; **an entity note is the spec for its Prisma model**.
- Implementing PRs should **cite the PRD id** (e.g. "Implements PRD-001") so code stays traceable to the document that produced it.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)