### PR TITLE
feat(appearance): default animated background on + show it on the homepage

### DIFF
--- a/src/components/common/overall-layout/layout.tsx
+++ b/src/components/common/overall-layout/layout.tsx
@@ -538,9 +538,10 @@ export default function RootLayout({
 
   return (
     <div className="flex h-[100dvh] w-screen flex-col overflow-hidden">
-      {/* Animated app background (opt-in via profile → Appearance). Skipped on
-          the marketing homepage, which renders its own background. */}
-      {appearanceMounted && backgroundEnabled && !isHomepage && (
+      {/* Animated app background (on by default; toggle in profile → Appearance).
+          Renders on every route including the homepage, behind the homepage's
+          own hero background. */}
+      {appearanceMounted && backgroundEnabled && (
         <div className="pointer-events-none fixed inset-0 -z-10">
           <Background
             variant="aurora"

--- a/src/components/pages/homepage/index.tsx
+++ b/src/components/pages/homepage/index.tsx
@@ -2,6 +2,7 @@ import ConnectWallet from "@/components/common/cardano-objects/connect-wallet";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Background } from "@/components/ui/background";
+import { useAppearanceStore } from "@/lib/zustand/appearance";
 import { MarbleField } from "@/components/ui/marble-field";
 import { FeatureIcon } from "@/components/pages/homepage/feature-icons";
 import { MultisigSigningExplainer } from "@/components/pages/homepage/multisig-explainer";
@@ -180,6 +181,16 @@ export function PageHomepage() {
   };
   const meshOpacity = calculateMeshOpacity();
 
+  // The homepage hero background follows the same appearance setting as the rest
+  // of the app. Default-show until mounted so the SSR markup and first client
+  // paint agree (avoids a hydration mismatch on the persisted preference).
+  const backgroundEnabled = useAppearanceStore((s) => s.backgroundEnabled);
+  const backgroundPreset = useAppearanceStore((s) => s.backgroundPreset);
+  const [appearanceMounted, setAppearanceMounted] = useState(false);
+  useEffect(() => setAppearanceMounted(true), []);
+  const heroBackgroundOn = !appearanceMounted || backgroundEnabled;
+  const heroPreset = appearanceMounted ? backgroundPreset : "aurora";
+
   const { data: newWallet } = api.wallet.getNewWallet.useQuery(
     { walletId: newWalletId! },
     {
@@ -189,23 +200,27 @@ export function PageHomepage() {
 
   return (
     <div className="relative w-full min-h-screen">
-      {/* Aurora Background - Fixed with Smooth Fade-Out */}
-      <div
-        className="fixed inset-0 -z-10 transition-opacity duration-700 ease-out"
-        style={{ opacity: topAuroraOpacity }}
-      >
-        <Background variant="aurora" />
-      </div>
+      {heroBackgroundOn && (
+        <>
+          {/* Aurora Background - Fixed with Smooth Fade-Out */}
+          <div
+            className="fixed inset-0 -z-10 transition-opacity duration-700 ease-out"
+            style={{ opacity: topAuroraOpacity }}
+          >
+            <Background variant="aurora" preset={heroPreset} />
+          </div>
 
-      {/* Marble swirls under a frosted-glass pane, above the aurora */}
-      <div
-        className="fixed inset-0 -z-10 transition-opacity duration-700 ease-out"
-        style={{ opacity: meshOpacity }}
-      >
-        <MarbleField />
-        {/* Frosted glass: a thin blur so the sharp marbling peeks through */}
-        <div className="absolute inset-0 backdrop-blur-sm bg-white/12 dark:bg-zinc-900/14" />
-      </div>
+          {/* Marble swirls under a frosted-glass pane, above the aurora */}
+          <div
+            className="fixed inset-0 -z-10 transition-opacity duration-700 ease-out"
+            style={{ opacity: meshOpacity }}
+          >
+            <MarbleField />
+            {/* Frosted glass: a thin blur so the sharp marbling peeks through */}
+            <div className="absolute inset-0 backdrop-blur-sm bg-white/12 dark:bg-zinc-900/14" />
+          </div>
+        </>
+      )}
 
       {/* Hero Section */}
       <section className="container mx-auto px-4 py-16 md:py-24">

--- a/src/lib/zustand/appearance.ts
+++ b/src/lib/zustand/appearance.ts
@@ -19,7 +19,7 @@ interface AppearanceState {
 export const useAppearanceStore = create<AppearanceState>()(
   persist(
     (set) => ({
-      backgroundEnabled: false,
+      backgroundEnabled: true,
       setBackgroundEnabled: (backgroundEnabled) => set({ backgroundEnabled }),
       backgroundPreset: "aurora",
       setBackgroundPreset: (backgroundPreset) => set({ backgroundPreset }),


### PR DESCRIPTION
Follow-up to #308 (already merged): two tweaks requested for the animated background.

## Changes
- **On by default** — `backgroundEnabled` now defaults to `true` (was opt-in off). Toggle still lives in Profile → Appearance.
- **Visible on the homepage** — the setting-driven app background now renders on **every** route including `/` (removed the `!isHomepage` exclusion). It sits behind the homepage's own hero background and persists as that hero background fades on scroll.
- The homepage's hero background now follows the **same toggle + selected preset** (so it matches the chosen style and turns off with the setting). A mounted guard keeps SSR and the first client paint in agreement (no hydration mismatch on the persisted preference).

## Notes
- On the homepage this means two background layers compose on the hero (the homepage's vibrant fading aurora + the persistent app layer, both in the chosen preset) — intentional, so the background stays visible the whole way down. If you'd rather have a single layer on home, I can drop the homepage's own and rely solely on the app layer.
- `tsc` clean · `jest` 362 passed · lint clean.
- Still pending a real-browser pass (worktree SSR/WASM + machine memory) — happy to do a Chrome MCP screenshot pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)