### PR TITLE
style(theme): extend glass-morphism to all cards

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,11 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border border-zinc-200/50 bg-white text-zinc-950 shadow dark:border-zinc-800/50 dark:bg-zinc-950 dark:text-zinc-50 overflow-hidden",
+      // Glass-morphism surface (matches the .glass-card design token): translucent
+      // + backdrop blur so the animated app background shows through. Opacity is
+      // kept high enough (80% light / 60% dark) to preserve text contrast on
+      // content-dense cards. Call sites can override the bg via className.
+      "rounded-xl border border-zinc-200/40 bg-white/80 text-zinc-950 shadow-sm backdrop-blur-md dark:border-white/10 dark:bg-zinc-900/60 dark:text-zinc-50 overflow-hidden",
       className
     )}
     {...props}


### PR DESCRIPTION
Runs the existing glass-morphism theme further through the platform.

## Context
The app already has a glass design system (`.glass-nav` / `.glass-card` / `.glass-subtle` in `globals.css`) and applies it to the **header and sidebar** (they get `backdrop-filter` blur). But the shared **`Card`** surface stayed opaque (`bg-white` / `dark:bg-zinc-950`), so page content didn't read as glass — and with the animated background now on by default, the background only peeked through the gutters.

## Change
Make the shared `Card` a **glass surface** — translucent + `backdrop-blur` — matching the `.glass-card` token. Because nearly every page card goes through `CardUI`/`Card`, this single change propagates glass across the whole app (wallet info, assets, governance, transactions, profile, …), so the chrome and the content now share one cohesive glass theme and the background shows through.

- Opacity kept high (**80% light / 60% dark**) so text stays readable on content-dense cards.
- Call sites can still override the background via `className` (e.g. the error-fallback card).

## Scope / deliberate boundaries
- **Nested content surfaces stay solid** (stat tiles, list rows, signer rows). Stacking `backdrop-blur` on a glass parent is muddy and GPU-heavy; solid content blocks on a glass container is the correct glass pattern.
- Works with the animated background **on or off** — over a solid page background the cards just read as a clean translucent surface.

## Verify
- `tsc` clean · `jest` 362 · lint clean.
- Visual: every page card becomes frosted glass; with the background on, the aurora shows through behind cards; text contrast holds.

Note: not yet checked in a running browser (worktree SSR/WASM + machine memory) — happy to do a Chrome-MCP pass on preprod. Perf to watch on card-dense pages on low-end mobile; blur radius is tunable in one place if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)