### PR TITLE
feat(landing): reduce the mouse-over effect on the background

### DIFF
--- a/src/components/ui/background.tsx
+++ b/src/components/ui/background.tsx
@@ -225,7 +225,7 @@ const Background = React.forwardRef<HTMLDivElement, BackgroundProps>(
           className="pointer-events-none absolute inset-0 transition-transform duration-500 ease-out"
           style={{
             transform:
-              "translate3d(calc(var(--aurora-px) * 26px), calc(var(--aurora-py) * 22px), 0)",
+              "translate3d(calc(var(--aurora-px) * 10px), calc(var(--aurora-py) * 8px), 0)",
           }}
         >
           {ORBS.map((orb, i) => (

--- a/src/components/ui/marble-field.tsx
+++ b/src/components/ui/marble-field.tsx
@@ -66,7 +66,7 @@ void main() {
     fbm(p + 3.5 * q + vec2(8.3, 2.8) - 0.5 * t)
   );
   float f = fbm(p + 3.5 * r);
-  f += 0.18 * exp(-md * 3.5); // cursor swells the marble
+  f += 0.07 * exp(-md * 4.5); // cursor gently swells the marble (subtle)
 
   // Muted, desaturated stone palette (slate / gray-blue / mauve).
   vec3 deep   = vec3(0.22, 0.24, 0.30);


### PR DESCRIPTION
Dials down the cursor reactivity on the landing background — it was a touch strong.

- **Aurora orb parallax**: the cursor-follow offset goes from `26/22px` to `10/8px`, so the orbs drift far less as the mouse moves.
- **Marble cursor swell**: amplitude `0.18 → 0.07` with a tighter falloff (`exp(-md*3.5)` → `-4.5`), so the swell around the pointer is gentler and covers a smaller area.

Two one-line changes (`background.tsx`, `marble-field.tsx`). `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)