### PR TITLE
perf(landing): stop the background animation only after it fully fades out

### DIFF
--- a/src/components/pages/homepage/index.tsx
+++ b/src/components/pages/homepage/index.tsx
@@ -161,7 +161,9 @@ export function PageHomepage() {
     const mainElement = document.querySelector("main");
     if (!mainElement) return;
 
+    const root = document.documentElement;
     let raf = 0;
+    let hideTimer = 0;
     const apply = () => {
       raf = 0;
       const y = mainElement.scrollTop;
@@ -170,6 +172,24 @@ export function PageHomepage() {
       const mesh = y < 500 ? 0.9 : y > 1500 ? 0 : 0.9 * (1 - (y - 500) / 1000);
       if (auroraRef.current) auroraRef.current.style.opacity = String(aurora);
       if (meshRef.current) meshRef.current.style.opacity = String(mesh);
+
+      // Once the background is fully faded out (invisible), stop animating it a
+      // beat later to save GPU — it keeps running the whole time it's visible
+      // or fading, and resumes instantly the moment it fades back in.
+      if (aurora === 0 && mesh === 0) {
+        if (!hideTimer && !root.hasAttribute("data-bg-hidden")) {
+          hideTimer = window.setTimeout(() => {
+            hideTimer = 0;
+            root.setAttribute("data-bg-hidden", "");
+          }, 800);
+        }
+      } else {
+        if (hideTimer) {
+          clearTimeout(hideTimer);
+          hideTimer = 0;
+        }
+        root.removeAttribute("data-bg-hidden");
+      }
     };
     const onScroll = () => {
       if (raf) return;
@@ -181,6 +201,8 @@ export function PageHomepage() {
     return () => {
       mainElement.removeEventListener("scroll", onScroll);
       if (raf) cancelAnimationFrame(raf);
+      if (hideTimer) clearTimeout(hideTimer);
+      root.removeAttribute("data-bg-hidden");
     };
   }, [heroBackgroundOn]);
 

--- a/src/components/ui/marble-field.tsx
+++ b/src/components/ui/marble-field.tsx
@@ -175,15 +175,17 @@ export function MarbleField({ className }: { className?: string }) {
       gl.drawArrays(gl.TRIANGLES, 0, 3);
     };
 
-    // Cap to ~30fps and skip work while the tab is hidden. The shader keeps
-    // running during scroll — at low resolution + 30fps its GPU cost is small
-    // enough to coexist with scroll compositing, so no need to pause it.
+    // Cap to ~30fps and skip work while the tab is hidden or the background has
+    // fully faded out (data-bg-hidden, set by the landing once it scrolls past
+    // the fade). It keeps running during scroll while still visible — at low
+    // resolution + 30fps its GPU cost coexists fine with scroll compositing.
     const FRAME_MS = 1000 / 30;
     let last = -Infinity;
     const loop = (timeMs: number) => {
       if (!running) return;
       raf = requestAnimationFrame(loop);
       if (document.hidden) return;
+      if (document.documentElement.hasAttribute("data-bg-hidden")) return;
       if (timeMs - last < FRAME_MS) return;
       last = timeMs;
       frame(timeMs);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -166,6 +166,14 @@
   animation: aurora-spin 48s linear infinite;
 }
 
+/* Once the landing background has fully faded out (PageHomepage sets
+   data-bg-hidden on <html> a beat after the scroll fade completes), pause the
+   aurora's animations — it's invisible, so this is imperceptible and frees the
+   GPU. Resumes instantly when it fades back in. */
+html[data-bg-hidden] [class*="animate-aurora"] {
+  animation-play-state: paused !important;
+}
+
 /* Feature-card icon animations */
 @keyframes feat-dash {
   to {


### PR DESCRIPTION
Re-opens a change that was lost: this was pushed onto #316 *after* #316 had already been merged, so it never reached preprod. (#316 only merged its first commit, "drop pause-on-scroll".)

## Behavior
- **While visible or fading (incl. during scroll):** the aurora + marble keep animating continuously.
- **After it fully fades out:** once the scroll fade hits 0 opacity, the animation stops **~800ms later** — imperceptible because the layer is already invisible — freeing the GPU for the rest of the long landing page.
- **Scrolling back up:** resumes instantly the moment it starts fading back in.

## How
- `homepage/index.tsx`: the ref/rAF scroll-fade sets `data-bg-hidden` on `<html>` ~800ms after both layers reach 0 opacity, clears it immediately when visible again (still no React re-render on scroll).
- `marble-field.tsx`: the WebGL loop skips its draw while `data-bg-hidden` (or tab hidden); keeps the 30fps cap + low-res.
- `globals.css`: `html[data-bg-hidden] [class*="animate-aurora"] { animation-play-state: paused }`.

`tsc` clean · `jest` 362 · lint clean. Independent of #317 (mouse-effect); they touch different lines and merge cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)