### PR TITLE
ci(migrations): run deploy-migrations on Node 22 + allow manual dispatch

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -5,6 +5,8 @@ on:
       - prisma/migrations/**
     branches:
       - main
+  # Allow manual runs so a migration can be applied without a fresh push under prisma/migrations/**
+  workflow_dispatch:
 
 jobs:
   deploy-migrations:
@@ -16,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           
       - name: Install dependencies


### PR DESCRIPTION
## Problem
The **Deploy Database Migrations** workflow runs `npm ci` on **Node 18**, but the repo now depends on **`prisma@7.8.0`**, which refuses to install on Node `<20.19` via a preinstall engine gate:

```
Prisma only supports Node.js versions 20.19+, 22.12+, 24.0+.
current: node v18.20.8
npm error command sh -c node scripts/preinstall-entry.js
```

So `npm ci` exits 1 **before** `prisma migrate deploy` ever runs. The job has been failing on every push to `main` that touches `prisma/migrations/**`.

**Production impact:** the most recent `main` run (after #303 merged) failed this way, so the `20260614120000_add_proposal_tally` migration was **not applied** — the `ProposalTally` table is missing in prod and the governance vote-tally router (#302) errors until it exists.

## Fix
- Bump `setup-node` to **22** (matches `pr-checks`, `unit-tests`, `trpc-integration-tests`, `ci-smoke-preprod`).
- Add a **`workflow_dispatch`** trigger. The workflow otherwise only fires on a push under `prisma/migrations/**`; since the migration is already merged (no new file to push), `workflow_dispatch` is the only way to apply it once this fix reaches `main`.

## After this lands on `main`
1. Re-run / manually dispatch **Deploy Database Migrations** to apply the pending `ProposalTally` migration to prod.
2. `daily-balance-snapshots.yml` also pins Node 18 but installs from the self-contained `scripts/` dir (no root Prisma) — left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
