### PR TITLE
Release: deploy-migrations Node 22 fix (unblocks prod migrations) + roadmap refresh

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -5,6 +5,8 @@ on:
       - prisma/migrations/**
     branches:
       - main
+  # Allow manual runs so a migration can be applied without a fresh push under prisma/migrations/**
+  workflow_dispatch:
 
 jobs:
   deploy-migrations:
@@ -16,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           
       - name: Install dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,6 +61,7 @@ Status of M1 tasks. Last updated 2026-04-23.
 | Task | Issues |
 |------|--------|
 | CI improvements — real-chain smoke system, deploy-migrations on Node 22, dependency/security hardening | #213 |
+| Email notification service — signature-required emails via Resend, notification center + outbox/worker, per-wallet settings, email verification | |
 
 ### Progress
 
@@ -74,6 +75,7 @@ Mid-month snapshot. Last updated 2026-06-17.
 | IPFS + rationale + ballot CSV | Done | Reliable IPFS proxy, rationale caching, ballot CSV ([#300](https://github.com/MeshJS/multisig/pull/300)); ReDoS hardening in `extractCidPath` ([#315](https://github.com/MeshJS/multisig/pull/315)) |
 | Platform UX foundations | Done | Mobile foundations ([#287](https://github.com/MeshJS/multisig/pull/287)–[#291](https://github.com/MeshJS/multisig/pull/291)), skeleton/empty states ([#289](https://github.com/MeshJS/multisig/pull/289)), error toasts ([#292](https://github.com/MeshJS/multisig/pull/292)), pagination/labels/assets ([#293](https://github.com/MeshJS/multisig/pull/293)–[#295](https://github.com/MeshJS/multisig/pull/295)), landing + SEO + theme ([#298](https://github.com/MeshJS/multisig/pull/298)/[#299](https://github.com/MeshJS/multisig/pull/299)/[#308](https://github.com/MeshJS/multisig/pull/308)–[#318](https://github.com/MeshJS/multisig/pull/318)) |
 | CI improvements | Done | Real-chain smoke system closed ([#213](https://github.com/MeshJS/multisig/issues/213)); deploy-migrations moved to Node 22 + manual dispatch ([#319](https://github.com/MeshJS/multisig/pull/319)); pg pool cap ([#284](https://github.com/MeshJS/multisig/pull/284)); npm override for brace-expansion ReDoS ([#301](https://github.com/MeshJS/multisig/pull/301)) |
+| Email notification service | In progress | Built on `feature/email-notification-center` (Resend email channel, notification center + outbox/worker, tRPC router, per-wallet settings UI, email verification, tests, plan doc); not yet merged to `preprod` |
 
 **Carryover into July:** complete the Mesh 2.0 runtime cutover; land the Node-22 deploy-migrations fix on `main` and apply the pending `ProposalTally` migration to production (governance tallies error until it exists); review the Supabase RLS advisory on the seven `rls_enabled: false` tables.
 
@@ -352,6 +354,7 @@ Aggregated view of the 12-month roadmap split by contributor. Each task has a si
 - [M1] CI smoke tests on real chain (#213)
 - [M1] Handle external PR — capability-based metadata (PR #208)
 - [M2] CI improvements — real-chain smoke system, deploy-migrations on Node 22, dependency/security hardening (#213)
+- [M2] Email notification service — signature-required emails via Resend, notification center + outbox/worker, per-wallet settings, email verification
 - [M3] Wallet V2 — on-chain registration and discovery (#33)
 - [M3] CI/maintenance baseline — keep suites green on Node 22, dependency/security updates
 - [M4–5] Document Sign-Off MVP — Documents UI, six-state lifecycle, signer review, diffs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,37 +44,59 @@ Status of M1 tasks. Last updated 2026-04-23.
 
 ## Month 2 — June 2026
 
-**Focus:** Mesh 2.0 upgrade and CI improvements.
+**Focus:** Mesh 2.0 migration groundwork, signing/auth reliability, in-app governance voting, and platform UX + CI hardening.
 
 **Quirin**
 
 | Task | Issues |
 |------|--------|
-| Mesh 2.0 upgrade — migrate to Mesh SDK 2.0 | |
+| Mesh 2.0 migration groundwork — Prisma 7 + Next 16 base, tx-builder hardfork-ready, consolidate wallet ops onto a single bridge (runtime stays on Mesh 1.9 until cutover) | #268, #269 |
+| Signing & auth reliability — bech32 normalization, Mesh-1.9 `signData` arg order, core-cst witness/body-hash merge, stuck-"Loading…" recovery, cross-instance import | |
+| In-app governance voting — Ekklesia/Hydra budget voting for multisig DReps, DRep-registration detection, ballot UX, proposal cards + DB-cached tallies | #122 |
+| IPFS reliability + rationale drafting/caching + ballot CSV | |
+| Platform UX foundations — mobile viewport/touch/dialogs/inputs, skeleton/empty states, error toasts, landing + SEO + theme overhaul | |
 
 **Andre**
 
 | Task | Issues |
 |------|--------|
-| CI improvements | |
+| CI improvements — real-chain smoke system, deploy-migrations on Node 22, dependency/security hardening | #213 |
+
+### Progress
+
+Mid-month snapshot. Last updated 2026-06-17.
+
+| Task | Status | Evidence |
+|------|--------|----------|
+| Mesh 2.0 migration groundwork | In progress | Prisma 7.8 + Next 16 on `preprod`; tx-builder hardfork upgrade ([#268](https://github.com/MeshJS/multisig/pull/268)) and Prisma 7 + mesh-2.0 staging merge ([#269](https://github.com/MeshJS/multisig/pull/269)); wallet ops consolidated on the Mesh 1.9 bridge with an ESLint guardrail ([#278](https://github.com/MeshJS/multisig/pull/278)) as cutover groundwork. Runtime still on `@meshsdk/core@^1.9`; full 2.0 cutover carries into July |
+| Signing & auth reliability | Done | bech32 normalization ([#273](https://github.com/MeshJS/multisig/pull/273)), Mesh-1.9 `signData` arg order ([#277](https://github.com/MeshJS/multisig/pull/277)), stuck-"Loading…" recovery ([#281](https://github.com/MeshJS/multisig/pull/281)/[#282](https://github.com/MeshJS/multisig/pull/282)), core-cst witness/body-hash merge ([#286](https://github.com/MeshJS/multisig/pull/286)), cross-instance mobile import ([#274](https://github.com/MeshJS/multisig/pull/274)) |
+| In-app governance voting | Done | Ekklesia/Hydra budget voting ([#272](https://github.com/MeshJS/multisig/pull/272)), DRep-registration detection ([#279](https://github.com/MeshJS/multisig/pull/279)), segmented ballot UX + type chips ([#296](https://github.com/MeshJS/multisig/pull/296)/[#297](https://github.com/MeshJS/multisig/pull/297)), proposal cards + DB-cached tallies ([#302](https://github.com/MeshJS/multisig/pull/302)). Closes the metadata hash-mismatch ([#122](https://github.com/MeshJS/multisig/issues/122)) ahead of its planned month |
+| IPFS + rationale + ballot CSV | Done | Reliable IPFS proxy, rationale caching, ballot CSV ([#300](https://github.com/MeshJS/multisig/pull/300)); ReDoS hardening in `extractCidPath` ([#315](https://github.com/MeshJS/multisig/pull/315)) |
+| Platform UX foundations | Done | Mobile foundations ([#287](https://github.com/MeshJS/multisig/pull/287)–[#291](https://github.com/MeshJS/multisig/pull/291)), skeleton/empty states ([#289](https://github.com/MeshJS/multisig/pull/289)), error toasts ([#292](https://github.com/MeshJS/multisig/pull/292)), pagination/labels/assets ([#293](https://github.com/MeshJS/multisig/pull/293)–[#295](https://github.com/MeshJS/multisig/pull/295)), landing + SEO + theme ([#298](https://github.com/MeshJS/multisig/pull/298)/[#299](https://github.com/MeshJS/multisig/pull/299)/[#308](https://github.com/MeshJS/multisig/pull/308)–[#318](https://github.com/MeshJS/multisig/pull/318)) |
+| CI improvements | Done | Real-chain smoke system closed ([#213](https://github.com/MeshJS/multisig/issues/213)); deploy-migrations moved to Node 22 + manual dispatch ([#319](https://github.com/MeshJS/multisig/pull/319)); pg pool cap ([#284](https://github.com/MeshJS/multisig/pull/284)); npm override for brace-expansion ReDoS ([#301](https://github.com/MeshJS/multisig/pull/301)) |
+
+**Carryover into July:** complete the Mesh 2.0 runtime cutover; land the Node-22 deploy-migrations fix on `main` and apply the pending `ProposalTally` migration to production (governance tallies error until it exists); review the Supabase RLS advisory on the seven `rls_enabled: false` tables.
 
 ---
 
 ## Month 3 — July 2026
 
-**Focus:** On-chain wallet discovery and FROST kickoff.
+**Focus:** Mesh 2.0 cutover, on-chain wallet discovery (Wallet V2), and FROST research kickoff.
 
 **Quirin**
 
 | Task | Issues |
 |------|--------|
-| FROST research kickoff | #220 |
+| Mesh 2.0 runtime cutover — move `@meshsdk/core`/`core-cst` off the 1.9 bridge to 2.0, byte-preserving signing so co-signers still sign identical bytes; drop the 1.9 ESLint guardrail once complete (carryover from June) | |
+| FROST research kickoff — survey Cardano-compatible FROST libraries + protocol readiness, draft the native-script vs threshold-Schnorr trade-off note, scope a PoC | #220 |
+| Production hardening follow-through — land the Node-22 deploy-migrations fix on `main`, apply the pending `ProposalTally` migration, review the Supabase RLS advisory | #319 |
 
 **Andre**
 
 | Task | Issues |
 |------|--------|
-| Wallet V2 — on-chain registration and discovery | #33 |
+| Wallet V2 — on-chain registration and discovery — design the on-chain registration record + discovery index, define the data model, prototype lookup by signer/policy | #33 |
+| CI/maintenance baseline — keep smoke + unit/tRPC suites green on Node 22, dependency/security updates | |
 
 ---
 
@@ -303,12 +325,18 @@ Aggregated view of the 12-month roadmap split by contributor. Each task has a si
 - [M1] Fix transaction loading bug (#211)
 - [M1] Handle external PR — Summon API routes (PR #212)
 - [M1] Fix legacy wallet compatibility bug
-- [M2] Mesh 2.0 upgrade — migrate to Mesh SDK 2.0
+- [M2] Mesh 2.0 migration groundwork — Prisma 7 + Next 16 base, tx-builder hardfork-ready, wallet-bridge consolidation (#268, #269)
+- [M2] Signing & auth reliability — bech32 normalization, signData arg order, core-cst witness/body-hash, stuck-loading recovery
+- [M2] In-app governance voting — Ekklesia/Hydra budget voting, DRep-registration detection, ballot UX, DB-cached tallies (#122)
+- [M2] IPFS reliability + rationale caching + ballot CSV
+- [M2] Platform UX foundations — mobile, skeleton/empty states, error toasts, landing + SEO + theme
+- [M3] Mesh 2.0 runtime cutover (carryover from M2)
 - [M3] FROST research kickoff (#220)
+- [M3] Production hardening follow-through — Node-22 migration CI on `main`, apply `ProposalTally`, RLS review (#319)
 - [M4–5] Document Sign-Off MVP — data model, routes, CIP-8 enforcement, proof export
 - [M6] Document Sign-Off v1 — Provenance (history, diff & rollback, audit export)
 - [M6] FROST research — deliver findings, PoC, go/no-go (#220)
-- [M7] Governance metadata fix (#122)
+- [M7] Governance metadata fix (#122) — ✅ closed early in June
 - [M7] dApp connector — external dApps request multi-sig transactions
 - [M8] Proxy voting polish and documentation
 - [M8] Transaction builder & tRPC integration tests (#255)
@@ -323,8 +351,9 @@ Aggregated view of the 12-month roadmap split by contributor. Each task has a si
 - [M1] Improve repository infrastructure — preprod environment and comprehensive smoke CI
 - [M1] CI smoke tests on real chain (#213)
 - [M1] Handle external PR — capability-based metadata (PR #208)
-- [M2] CI improvements
+- [M2] CI improvements — real-chain smoke system, deploy-migrations on Node 22, dependency/security hardening (#213)
 - [M3] Wallet V2 — on-chain registration and discovery (#33)
+- [M3] CI/maintenance baseline — keep suites green on Node 22, dependency/security updates
 - [M4–5] Document Sign-Off MVP — Documents UI, six-state lifecycle, signer review, diffs
 - [M6] Hardware wallet support — Ledger/Trezor (#44)
 - [M7] Pending transactions on homepage (#125)


### PR DESCRIPTION
Promotes the post-#303 work on `preprod` to `main` (2 changes).

## CI fix — unblocks production migrations
- **`deploy-migrations` now runs on Node 22 + supports manual dispatch** ([#319](https://github.com/MeshJS/multisig/pull/319)). The workflow was pinned to Node 18, which can't install `prisma@7.8.0` (preinstall engine gate), so `npm ci` failed before `prisma migrate deploy` ever ran — that's why the `ProposalTally` migration from #303 never reached production.

## Docs
- **Roadmap June/July refresh** ([#320](https://github.com/MeshJS/multisig/pull/320)): real per-owner June tasks + a dated progress snapshot, fleshed-out July deliverables, and Andre's in-progress email notification service.

## ⚠️ Deploy checklist for main
- This merge changes `.github/workflows/` and `ROADMAP.md` only — it does **not** touch `prisma/migrations/**`, so merging will **not** auto-trigger the deploy-migrations workflow.
- **After merge:** manually run the **Deploy Database Migrations** workflow on `main` (now possible via `workflow_dispatch`) to apply the still-pending `20260614120000_add_proposal_tally` migration. The `ProposalTally` table is currently missing in prod and the governance tally router errors until it exists.
- Separately tracked: the Supabase advisory flagging RLS disabled on 7 tables — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
