### PR TITLE
fix(auth): create User after authorization so login isn't stuck on "Authorize"

### DIFF
--- a/src/components/common/overall-layout/layout.tsx
+++ b/src/components/common/overall-layout/layout.tsx
@@ -115,7 +115,7 @@ export default function RootLayout({
   const router = useRouter();
   const { appWallet } = useAppWallet();
   const { multisigWallet } = useMultisigWallet();
-  const { isEnabled: isUtxosEnabled } = useUTXOS();
+  const { isEnabled: isUtxosEnabled, wallet: utxosWallet } = useUTXOS();
 
   const userAddress = useUserStore((state) => state.userAddress);
   const setUserAddress = useUserStore((state) => state.setUserAddress);
@@ -436,13 +436,69 @@ export default function RootLayout({
     setHasCheckedSession(true); // Mark as checked so we don't check again
     // Show loading skeleton for smooth transition
     setShowPostAuthLoading(true);
-    
+
     // Wait a moment for the cookie to be set by the browser, then refetch session
     await new Promise(resolve => setTimeout(resolve, 200));
-    
+
     // Refetch session to update state
     await refetchWalletSession();
-    
+
+    // Create/ensure the User row now that the wallet session cookie exists.
+    //
+    // createUser is a protectedProcedure (it needs a session). The onboarding
+    // effects fire createUser on *connect* (regular wallets in initializeWallet
+    // below; UTXOS in connect-wallet) — which happens seconds before the user
+    // approves the signing prompt — so that first attempt always runs
+    // unauthenticated and is rejected UNAUTHORIZED, and it never retries once the
+    // cookie lands. The result: useUser() stays null and the connect button is
+    // stuck on "Authorize" even though signing succeeded. Re-run it here, after
+    // authorization, when the cookie is actually present — for both regular
+    // browser wallets and the UTXOS smart wallet.
+    try {
+      const authedAddress = userAddress || address;
+      if (authedAddress) {
+        let stakeAddress: string | undefined;
+        let drepKeyHash = "";
+
+        if (activeWallet) {
+          // Regular browser wallet: stake from the wallet, DRep from the 1.9 IWallet.
+          stakeAddress = (await activeWallet.getRewardAddresses())[0];
+          try {
+            const dRepKey = await meshWallet?.getDRep();
+            if (dRepKey?.publicKeyHash) {
+              drepKeyHash = dRepKey.publicKeyHash;
+            }
+          } catch {
+            // DRep key is optional
+          }
+        } else if (isUtxosEnabled && utxosWallet?.cardano) {
+          // UTXOS smart wallet: stake + DRep come from its CIP-30 interface.
+          stakeAddress = (await utxosWallet.cardano.getRewardAddresses())[0];
+          try {
+            if (typeof utxosWallet.cardano.getDRep === "function") {
+              const dRepKey = await utxosWallet.cardano.getDRep();
+              if (dRepKey && typeof dRepKey === "object" && "publicKeyHash" in dRepKey) {
+                drepKeyHash = (dRepKey as { publicKeyHash: string }).publicKeyHash;
+              }
+            }
+          } catch {
+            // DRep key is optional
+          }
+        }
+
+        if (stakeAddress) {
+          createUser({
+            address: authedAddress,
+            stakeAddress: normalizeAddressToBech32(stakeAddress),
+            drepKeyHash,
+          });
+        }
+      }
+    } catch {
+      // Non-fatal: the onboarding effects will retry on a later render now that
+      // the session cookie is present.
+    }
+
     // Invalidate wallet queries so they refetch with the new session
     // Use a small delay to ensure cookie is available on subsequent requests
     setTimeout(() => {
@@ -458,7 +514,7 @@ export default function RootLayout({
     setTimeout(() => {
       setShowPostAuthLoading(false);
     }, 1500);
-  }, [refetchWalletSession, ctx.wallet, userAddress, address]);
+  }, [refetchWalletSession, ctx.wallet, userAddress, address, activeWallet, meshWallet, isUtxosEnabled, utxosWallet, createUser]);
 
   // Memoize computed route values
   const isWalletPath = useMemo(() => router.pathname.includes("/wallets/[wallet]"), [router.pathname]);


### PR DESCRIPTION
## Problem

First-time login (and anyone whose 7-day session cookie expired) gets stuck: the wallet connects and signing succeeds, but the connect button stays on **"Authorize"** and no User is created.

## Root cause

`createUser` is a `protectedProcedure` (it requires a wallet session), but the onboarding effects call it on **connect** — seconds before the user approves the signing prompt. That first attempt always runs unauthenticated → `UNAUTHORIZED` (failing silently), and it **never retries** once the wallet-session cookie is set. So `useUser()` stays `null` and the button is stuck on "Authorize".

Returning users with a still-valid 7-day cookie were unaffected (their connect-time `createUser` runs *with* the cookie), which is why this slipped through the Mesh 2.0 / preprod merge (#269).

The backend verify path is healthy — verified end-to-end against production: `getNonce` → `signData` → `POST /api/auth/wallet-session` returns `200 {ok:true}` for a valid signature. The break is purely the user-record onboarding sequence.

## Fix

Re-run `createUser` in `handleAuthModalAuthorized` — **after** the wallet-session cookie exists — for both wallet types the auth modal serves:
- **Regular browser wallets:** stake address from the wallet, DRep key from the 1.9 `IWallet`.
- **UTXOS smart wallet:** stake + DRep from its CIP-30 interface.

The connect-time attempts are left as-is (they succeed for returning users with a live cookie); the post-auth call is purely additive and idempotent (`upsert`).

## Verification

- `tsc --noEmit`: no new type errors (`layout.tsx` clean; pre-existing errors are unrelated stale-Prisma/dev-dep noise in the worktree).
- To confirm in-app: connect a fresh wallet (or after clearing the `mesh_wallet_session` cookie), approve the signing prompt — the button should resolve to "Connected" without a manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)