### PR TITLE
feat: AI-agent landing section + SEO blog

### DIFF
--- a/src/components/common/overall-layout/site-footer.tsx
+++ b/src/components/common/overall-layout/site-footer.tsx
@@ -6,6 +6,7 @@ const productLinks = [
   { label: "Governance", href: "/governance" },
   { label: "DRep Explorer", href: "/governance/drep" },
   { label: "Import a wallet", href: "/wallets/import-wallet" },
+  { label: "Blog", href: "/blog" },
 ];
 
 const developerLinks = [

--- a/src/components/pages/blog/index.tsx
+++ b/src/components/pages/blog/index.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import type { ArticleMeta } from "@/lib/seo";
+import { Reveal } from "@/components/ui/reveal";
+
+/** Format an ISO date (YYYY-MM-DD) as e.g. "June 29, 2026" in UTC (stable). */
+export function formatDate(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export default function PageBlogIndex({ posts }: { posts: ArticleMeta[] }) {
+  return (
+    <div>
+      <section className="container mx-auto px-4 py-16 md:py-20">
+        <Reveal className="mx-auto max-w-3xl text-center">
+          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">Blog</h1>
+          <p className="mx-auto mt-4 max-w-2xl text-lg text-muted-foreground">
+            Guides and updates on Cardano multisig treasuries, governance, and
+            AI-agent automation — from the team behind Mesh Multisig.
+          </p>
+        </Reveal>
+
+        <div className="mx-auto mt-12 max-w-3xl space-y-6">
+          {posts.length === 0 ? (
+            <p className="text-center text-muted-foreground">
+              No posts yet — check back soon.
+            </p>
+          ) : (
+            posts.map((post, i) => (
+              <Reveal key={post.slug} delayMs={i * 60}>
+                <Link
+                  href={`/blog/${post.slug}`}
+                  className="block rounded-2xl border border-zinc-200/70 bg-white/60 p-6 shadow-sm backdrop-blur-sm transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-md hover:no-underline dark:border-zinc-800/70 dark:bg-zinc-900/40 dark:hover:border-zinc-700"
+                >
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <time dateTime={post.date}>{formatDate(post.date)}</time>
+                    {post.tags?.slice(0, 3).map((t) => (
+                      <span
+                        key={t}
+                        className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                  <h2 className="mt-2 text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+                    {post.title}
+                  </h2>
+                  <p className="mt-2 text-muted-foreground">{post.description}</p>
+                  <span className="mt-4 inline-flex items-center text-sm font-medium text-primary">
+                    Read more →
+                  </span>
+                </Link>
+              </Reveal>
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/pages/blog/post.tsx
+++ b/src/components/pages/blog/post.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { ArrowLeft, Download } from "lucide-react";
+import type { BlogPost } from "@/lib/blog";
+import { Reveal } from "@/components/ui/reveal";
+import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
+import { formatDate } from "@/components/pages/blog";
+
+// Prose styling via arbitrary child selectors — the repo has no @tailwindcss/typography.
+const PROSE =
+  "max-w-none text-[15px] leading-relaxed text-muted-foreground " +
+  "[&_h2]:mt-10 [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:tracking-tight [&_h2]:text-foreground " +
+  "[&_h3]:mt-8 [&_h3]:text-xl [&_h3]:font-semibold [&_h3]:text-foreground " +
+  "[&_p]:mt-4 [&_ul]:mt-4 [&_ul]:list-disc [&_ul]:pl-6 [&_ol]:mt-4 [&_ol]:list-decimal [&_ol]:pl-6 " +
+  "[&_li]:mt-1.5 [&_li>strong]:text-foreground " +
+  "[&_a]:font-medium [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 " +
+  "[&_strong]:font-semibold [&_strong]:text-foreground " +
+  "[&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-sm [&_code]:font-mono " +
+  "[&_pre]:mt-4 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-zinc-950 [&_pre]:p-4 [&_pre]:text-sm [&_pre]:text-zinc-100 [&_pre_code]:bg-transparent [&_pre_code]:p-0 " +
+  "[&_blockquote]:mt-4 [&_blockquote]:border-l-2 [&_blockquote]:border-zinc-300 [&_blockquote]:pl-4 [&_blockquote]:italic dark:[&_blockquote]:border-zinc-700 " +
+  "[&_hr]:my-8 [&_hr]:border-border " +
+  "[&_table]:mt-4 [&_table]:w-full [&_th]:border [&_th]:border-border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_td]:border [&_td]:border-border [&_td]:px-3 [&_td]:py-2";
+
+export default function PageBlogPost({ post }: { post: BlogPost }) {
+  const { meta, content } = post;
+
+  return (
+    <div>
+      <article className="container mx-auto px-4 py-12 md:py-16">
+        <div className="mx-auto max-w-3xl">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            All posts
+          </Link>
+
+          <Reveal className="mt-6">
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <time dateTime={meta.date}>{formatDate(meta.date)}</time>
+              {meta.tags?.slice(0, 4).map((t) => (
+                <span
+                  key={t}
+                  className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium"
+                >
+                  {t}
+                </span>
+              ))}
+            </div>
+            <h1 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+              {meta.title}
+            </h1>
+            <p className="mt-3 text-lg text-muted-foreground">
+              {meta.description}
+            </p>
+          </Reveal>
+
+          <Separator className="my-8" />
+
+          <div className={PROSE}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+          </div>
+
+          {/* CTA */}
+          <div className="mt-12 rounded-2xl border border-zinc-200/70 bg-white/60 p-6 backdrop-blur-sm dark:border-zinc-800/70 dark:bg-zinc-900/40">
+            <h2 className="text-lg font-semibold">Ready to try it?</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Create a multisig wallet, or drop the skill into your AI agent to
+              automate the busywork — signing always stays with you.
+            </p>
+            <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+              <Button asChild>
+                <Link href="/">Open Mesh Multisig</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <a href="/api/skill" download="multisig-skill.md">
+                  <Download className="mr-2 h-4 w-4" />
+                  Download skill
+                </a>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/src/components/pages/homepage/index.tsx
+++ b/src/components/pages/homepage/index.tsx
@@ -14,8 +14,9 @@ import CardUI from "@/components/ui/card-content";
 import RowLabelInfo from "@/components/common/row-label-info";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
-import { Database, Bot, Code, Download, Check } from "lucide-react";
+import { Database, Bot, Code, Download, Check, Sparkles } from "lucide-react";
 import { Reveal } from "@/components/ui/reveal";
+import { Typewriter } from "@/components/ui/typewriter";
 import {
   MultisigWalletPreview,
   WalletListPreview,
@@ -27,6 +28,16 @@ import {
   DRepPreview,
   StakingPreview,
 } from "@/components/pages/homepage/previews";
+
+// Example prompts cycled by the "Connect your AI agent" typewriter. The first
+// is the literal flow most users start with; the rest hint at what an agent can
+// do once it holds the multisig skill.
+const AGENT_PROMPTS = [
+  "Connect to my https://multisig.meshjs.dev/ wallet",
+  "List the pending transactions on our treasury",
+  "Draft a 200 ₳ payout to the dev fund and request signatures",
+  "Show who still needs to sign the pending payout",
+];
 
 // DApp Card Component
 function DappCard({ title, description, url }: { title: string; description: string; url: string }) {
@@ -279,6 +290,64 @@ export function PageHomepage() {
           <p className="mt-6 text-sm text-muted-foreground">
             Secure Treasuries • Participate in Governance • Collaborate
           </p>
+        </Reveal>
+      </section>
+
+      {/* Connect your AI agent – skill download + live prompt demo, up top */}
+      <section className="container mx-auto px-4 pb-8">
+        <Reveal className="mx-auto max-w-5xl">
+          <div className="overflow-hidden rounded-2xl border border-zinc-200/70 bg-white/60 p-6 shadow-sm backdrop-blur-sm dark:border-zinc-800/70 dark:bg-zinc-900/40 sm:p-8 md:p-10">
+            <div className="grid items-center gap-8 md:grid-cols-2">
+              {/* Copy + actions */}
+              <div>
+                <div className="inline-flex items-center gap-2 rounded-full border border-zinc-200 bg-muted/60 px-3 py-1 text-xs font-medium text-muted-foreground dark:border-zinc-800">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  AI-native multisig
+                </div>
+                <h2 className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">
+                  Connect your AI agent
+                </h2>
+                <p className="mt-3 text-muted-foreground">
+                  Drop the multisig skill into Claude Code, Cursor, or any agent and let
+                  it work alongside your treasury — read pending transactions, draft
+                  payouts, and track approvals through the authenticated v1 API. The
+                  agent can&apos;t sign for you: keys and signatures always stay with you
+                  and your co-signers.
+                </p>
+                <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <Button asChild size="lg">
+                    <a href="/api/skill" download="multisig-skill.md">
+                      <Download className="mr-2 h-4 w-4" />
+                      Download skill
+                    </a>
+                  </Button>
+                  <Button asChild size="lg" variant="outline">
+                    <Link href="#developers-and-bots">
+                      <Bot className="mr-2 h-4 w-4" />
+                      Developer &amp; bot docs
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+
+              {/* Animated agent prompt */}
+              <div className="rounded-xl border border-zinc-800 bg-zinc-950 p-4 font-mono text-sm text-zinc-100 shadow-lg sm:p-5">
+                <div className="flex items-center gap-1.5 pb-3">
+                  <span className="h-3 w-3 rounded-full bg-red-400/80" />
+                  <span className="h-3 w-3 rounded-full bg-yellow-400/80" />
+                  <span className="h-3 w-3 rounded-full bg-green-400/80" />
+                  <span className="ml-2 text-xs text-zinc-500">agent</span>
+                </div>
+                <div className="flex min-h-[5rem] items-start gap-2 leading-relaxed">
+                  <span className="select-none text-emerald-400">›</span>
+                  <Typewriter phrases={AGENT_PROMPTS} className="text-zinc-100" />
+                </div>
+                <div className="mt-3 border-t border-zinc-800 pt-3 text-xs text-zinc-500">
+                  Read &amp; draft only — signing stays with you and your co-signers.
+                </div>
+              </div>
+            </div>
+          </div>
         </Reveal>
       </section>
 

--- a/src/components/ui/metatags.tsx
+++ b/src/components/ui/metatags.tsx
@@ -28,6 +28,8 @@ export default function Metatags({
   /** Open Graph object type. "website" for marketing pages, "article" for content. */
   type = "website",
   noindex = false,
+  /** Extra JSON-LD blocks (e.g. an Article) appended to the site-wide ones. */
+  extraJsonLd,
 }: {
   title?: string;
   description?: string;
@@ -36,10 +38,15 @@ export default function Metatags({
   path?: string;
   type?: string;
   noindex?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  extraJsonLd?: Record<string, any>[];
 }) {
   const canonical = absoluteUrl(path);
   const imageUrl = absoluteUrl(image);
-  const jsonLd = JSON.stringify(buildJsonLd(path));
+  const jsonLd = JSON.stringify([
+    ...buildJsonLd(path),
+    ...(extraJsonLd ?? []),
+  ]);
 
   return (
     <>

--- a/src/components/ui/typewriter.tsx
+++ b/src/components/ui/typewriter.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+
+/**
+ * Types a cycling list of phrases one character at a time, then deletes and
+ * advances to the next — a classic "typewriter" prompt effect.
+ *
+ * - Honors `prefers-reduced-motion`: reduced-motion users see the first phrase
+ *   rendered statically with no typing/deleting and a non-blinking caret.
+ * - SSR-safe: the first paint is an empty string (matches server output), so
+ *   there is no hydration mismatch; animation only starts after mount.
+ * - All timers are cleared on unmount / dependency change.
+ */
+export function Typewriter({
+  phrases,
+  className,
+  typeMs = 45,
+  deleteMs = 25,
+  holdMs = 1600,
+  startDelayMs = 350,
+}: {
+  phrases: string[];
+  className?: string;
+  /** ms per character while typing */
+  typeMs?: number;
+  /** ms per character while deleting */
+  deleteMs?: number;
+  /** ms to hold a fully-typed phrase before deleting */
+  holdMs?: number;
+  /** ms to wait before the first character is typed */
+  startDelayMs?: number;
+}) {
+  const reduced = useReducedMotion();
+  const [text, setText] = useState("");
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const first = phrases[0] ?? "";
+
+  useEffect(() => {
+    if (reduced || phrases.length === 0) {
+      setText(first);
+      return;
+    }
+
+    let phrase = 0;
+    let char = 0;
+    let deleting = false;
+
+    const tick = () => {
+      const current = phrases[phrase] ?? "";
+
+      if (!deleting) {
+        char += 1;
+        setText(current.slice(0, char));
+        if (char === current.length) {
+          deleting = true;
+          timer.current = setTimeout(tick, holdMs);
+          return;
+        }
+        timer.current = setTimeout(tick, typeMs);
+        return;
+      }
+
+      char -= 1;
+      setText(current.slice(0, char));
+      if (char === 0) {
+        deleting = false;
+        phrase = (phrase + 1) % phrases.length;
+        timer.current = setTimeout(tick, typeMs * 4);
+        return;
+      }
+      timer.current = setTimeout(tick, deleteMs);
+    };
+
+    timer.current = setTimeout(tick, startDelayMs);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+    // phrases is treated as a stable literal by callers; join keeps the effect
+    // honest if the list ever changes without remounting.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reduced, phrases.join(""), typeMs, deleteMs, holdMs, startDelayMs]);
+
+  return (
+    <span className={cn("whitespace-pre-wrap break-words", className)}>
+      {text}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "ml-0.5 inline-block w-[1px] -translate-y-[1px] self-stretch border-r-2 border-current align-middle",
+          reduced ? "opacity-70" : "animate-pulse",
+        )}
+        style={{ height: "1em" }}
+      />
+    </span>
+  );
+}
+
+export default Typewriter;

--- a/src/content/blog/connect-an-ai-agent-to-your-cardano-multisig.md
+++ b/src/content/blog/connect-an-ai-agent-to-your-cardano-multisig.md
@@ -1,0 +1,46 @@
+---
+title: "Connect an AI agent to your Cardano multisig"
+description: "Drop the Mesh Multisig skill into Claude Code, Cursor, or any agent and let it read pending transactions, draft payouts, and track approvals through the REST v1 API — without ever holding your keys."
+date: "2026-06-29"
+tags: ["ai agents", "cardano multisig", "automation", "developer tools"]
+author: "Mesh"
+---
+
+AI agents are good at the parts of treasury work that humans find tedious: watching for pending transactions, drafting routine payouts, reconciling who has signed what, and summarizing activity. They are **not** something you should ever hand your signing keys to. Mesh Multisig is built around exactly that split — an agent can do the busywork, while signing stays with you and your co-signers.
+
+This post walks through connecting an AI agent to your multisig wallet using the downloadable **multisig skill**.
+
+## What the skill gives your agent
+
+The skill is a single Markdown file that teaches an agent how Mesh Multisig works: the REST v1 endpoints, bot authentication, wallet flows, and the conventions the API expects. Drop it into Claude Code, Cursor, or any agent framework and it can immediately reason about your treasury.
+
+You can grab it from the **Download skill** button on the homepage, or directly from `/api/skill`.
+
+## What an agent can — and can't — do
+
+Once connected, an agent works through the same authenticated v1 API a bot uses. In practice that means it can:
+
+- **Read pending transactions** for any wallet it has access to
+- **List free UTxOs** and wallet balances
+- **Draft transactions** and queue them for the required signers
+- **Track approvals** — report who still needs to sign to reach quorum
+
+What it cannot do is sign. Signatures are produced by the human co-signers holding the keys; the agent never sees them. This is the whole point of multisig: no single party — human or machine — can move funds alone.
+
+## A typical prompt
+
+Connecting is as simple as pointing the agent at your wallet:
+
+> Connect to my https://multisig.meshjs.dev/ wallet, list the pending transactions on our treasury, and tell me who still needs to sign the latest payout.
+
+The agent authenticates, queries the v1 endpoints, and reports back. When it drafts a new payout, the transaction lands in your pending queue for the signers to review and approve — exactly as if a teammate had created it.
+
+## Authentication, briefly
+
+Agents authenticate as bots. You create a bot key in the app (**User → Create bot**), then the agent calls `POST /api/v1/botAuth` with the key and a payment address to receive a short-lived JWT. Every subsequent request carries that token. Each bot key maps to one payment address, which is the identity used across `walletIds`, `pendingTransactions`, `freeUtxos`, and the rest of the v1 surface.
+
+## Why this is safe by design
+
+Because signing authority is cryptographic and stays with the key holders, granting an agent API access is low-risk: the worst it can do is read data and propose transactions that still require human approval. You get automation without surrendering custody.
+
+Ready to try it? Download the skill, create a bot key, and point your agent at your wallet.

--- a/src/content/blog/what-is-cardano-multisig.md
+++ b/src/content/blog/what-is-cardano-multisig.md
@@ -1,0 +1,52 @@
+---
+title: "What is Cardano multisig? A guide to M-of-N treasuries"
+description: "A plain-English guide to multi-signature wallets on Cardano: how native-script M-of-N signing works, why teams and DAOs use it, and how to set up a multisig treasury with Mesh Multisig."
+date: "2026-06-26"
+tags: ["cardano multisig", "treasury", "native scripts", "dao", "security"]
+author: "Mesh"
+---
+
+A **multisig** (multi-signature) wallet requires more than one signature to move funds. Instead of a single private key controlling the money, a group of signers each hold their own key, and a transaction only settles once enough of them approve. On Cardano this is enforced on-chain by **native scripts** — no smart contract or custodian required.
+
+## M-of-N signing
+
+Multisig is usually described as **M-of-N**: of `N` total signers, any `M` must sign for a transaction to be valid. A few common shapes:
+
+- **2-of-3** — a small team where any two members can act, tolerant of one lost key
+- **3-of-5** — a DAO working group that wants a real quorum before funds move
+- **all-of-N** — every signer must approve, for maximum control
+
+You choose the threshold per wallet. The moment the `M`-th valid signature lands, the transaction can be submitted; until then, the funds simply can't move.
+
+## Why teams use it
+
+A single private key is a single point of failure: lose it and the funds are gone; leak it and they're stolen. Multisig removes that:
+
+- **No single point of failure.** One compromised or lost key isn't enough to move funds.
+- **Shared control.** Treasuries belong to the group, not to whoever happens to hold the key.
+- **Accountability.** Every signer is invited and verified, and every approval is recorded.
+
+This is why DAOs, project treasuries, and multi-person teams reach for multisig rather than passing one seed phrase around.
+
+## How it works on Cardano
+
+Cardano's native scripts express signing rules directly at the protocol level. A multisig wallet is defined by a script listing the signers' key hashes and the required threshold. Because it's native, validation is cheap, predictable, and doesn't depend on a third-party contract.
+
+When someone proposes a transaction, it's shared with the other signers. Each signs with their own wallet, contributing a witness. Once the threshold is met, the combined transaction is submitted to the chain.
+
+## Setting up a multisig with Mesh Multisig
+
+[Mesh Multisig](/) is a free, open-source, Cardano-native wallet built for exactly this:
+
+1. **Create a wallet** and choose your `M`-of-`N` threshold.
+2. **Invite signers** with a link; each is verified before they're added.
+3. **Propose transactions** and route them to the required signers.
+4. **Review and sign** — anyone can see pending transactions and who has approved.
+
+You can also participate in **Cardano governance** as a group — vote on proposals and register as a DRep — all under the same multi-signature security.
+
+## Going further
+
+Once your treasury is running, you can automate the read-and-draft busywork by [connecting an AI agent](/blog/connect-an-ai-agent-to-your-cardano-multisig) or a bot to the REST API — while signing stays firmly with your co-signers.
+
+Multisig turns a treasury from "whoever holds the key" into a transparent, shared, fault-tolerant system. On Cardano, it's native, free to use, and a few minutes to set up.

--- a/src/data/public-routes.ts
+++ b/src/data/public-routes.ts
@@ -6,6 +6,8 @@ export const publicRoutes = [
   "/features",
   "/api-docs",
   "/dapps",
+  "/blog",
+  "/blog/[slug]",
   // The import wizard renders before a wallet is connected so the user
   // can see what's available; per-tab actions (sign, submit) still gate
   // on a live wallet connection.

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,118 @@
+import fs from "fs";
+import path from "path";
+import type { ArticleMeta } from "@/lib/seo";
+import { BLOG_AUTHOR } from "@/lib/seo";
+
+/**
+ * File-based blog data layer.
+ *
+ * Posts are Markdown files in `src/content/blog/*.md` with a small YAML-ish
+ * front-matter block. This is server-only (uses `fs`) — call it exclusively from
+ * `getServerSideProps` / `getStaticProps` / API routes, never from a component.
+ *
+ * We deliberately avoid a front-matter dependency (gray-matter): the format is
+ * fully under our control, so a tiny parser keeps the feature self-contained.
+ */
+
+const BLOG_DIR = path.join(process.cwd(), "src", "content", "blog");
+
+export type BlogPost = {
+  meta: ArticleMeta;
+  /** Raw Markdown body (front-matter stripped). */
+  content: string;
+};
+
+/** Parse a single front-matter scalar: JSON string, JSON array, or bare text. */
+function parseValue(raw: string): string | string[] {
+  const t = raw.trim();
+  if (t.startsWith("[")) {
+    try {
+      return JSON.parse(t) as string[];
+    } catch {
+      return [];
+    }
+  }
+  if (
+    (t.startsWith('"') && t.endsWith('"')) ||
+    (t.startsWith("'") && t.endsWith("'"))
+  ) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+/** Split a raw file into its front-matter object and Markdown body. */
+function parseFrontmatter(raw: string): {
+  data: Record<string, string | string[]>;
+  content: string;
+} {
+  const normalized = raw.replace(/\r\n/g, "\n");
+  const match = normalized.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) return { data: {}, content: normalized.trim() };
+
+  const data: Record<string, string | string[]> = {};
+  for (const line of match[1]!.split("\n")) {
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    data[key] = parseValue(line.slice(idx + 1));
+  }
+  return { data, content: normalized.slice(match[0].length).trim() };
+}
+
+function str(v: string | string[] | undefined, fallback = ""): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+function toMeta(
+  slug: string,
+  data: Record<string, string | string[]>,
+): ArticleMeta {
+  const tags = Array.isArray(data.tags)
+    ? data.tags
+    : typeof data.tags === "string" && data.tags
+      ? data.tags.split(",").map((t) => t.trim()).filter(Boolean)
+      : [];
+  // Optional fields are omitted entirely (never set to `undefined`) so the meta
+  // stays JSON-serializable for getServerSideProps props.
+  const meta: ArticleMeta = {
+    slug,
+    title: str(data.title, slug),
+    description: str(data.description),
+    date: str(data.date),
+    author: str(data.author) || BLOG_AUTHOR,
+  };
+  const updated = str(data.updated);
+  if (updated) meta.updated = updated;
+  if (tags.length) meta.tags = tags;
+  const image = str(data.image);
+  if (image) meta.image = image;
+  return meta;
+}
+
+/** All post slugs (filenames without the `.md` extension). */
+export function getPostSlugs(): string[] {
+  if (!fs.existsSync(BLOG_DIR)) return [];
+  return fs
+    .readdirSync(BLOG_DIR)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => f.replace(/\.md$/, ""));
+}
+
+/** A single post (metadata + Markdown body), or `null` if the slug is unknown. */
+export function getPostBySlug(slug: string): BlogPost | null {
+  const safe = slug.replace(/[^a-z0-9-]/gi, "");
+  const file = path.join(BLOG_DIR, `${safe}.md`);
+  if (!safe || !fs.existsSync(file)) return null;
+  const { data, content } = parseFrontmatter(fs.readFileSync(file, "utf8"));
+  return { meta: toMeta(safe, data), content };
+}
+
+/** All post metadata, newest first. */
+export function getAllPostsMeta(): ArticleMeta[] {
+  return getPostSlugs()
+    .map((slug) => getPostBySlug(slug)?.meta)
+    .filter((m): m is ArticleMeta => Boolean(m))
+    .sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -83,6 +83,18 @@ export const routeSeo: Record<string, RouteSeo> = {
     description:
       "Use Mesh Multisig with your favourite Cardano DApps in multi-signature mode.",
   },
+  "/blog": {
+    title: "Blog",
+    description:
+      "Guides and updates on Cardano multisig treasuries, governance and AI-agent automation from the team behind Mesh Multisig.",
+  },
+  "/blog/[slug]": {
+    // Per-post title/description/Article JSON-LD are supplied at request time via
+    // `pageProps.seo` (see buildPostSeo); these are only the fallback.
+    title: "Blog",
+    description:
+      "Guides and updates on Cardano multisig treasuries, governance and AI-agent automation from the team behind Mesh Multisig.",
+  },
   "/wallets/import-wallet": {
     title: "Import a Multisig Wallet",
     description:
@@ -140,6 +152,7 @@ export type SitemapRoute = {
 export const INDEXABLE_ROUTES: SitemapRoute[] = [
   { path: "/", changefreq: "weekly", priority: 1.0 },
   { path: "/features", changefreq: "monthly", priority: 0.8 },
+  { path: "/blog", changefreq: "weekly", priority: 0.7 },
   { path: "/governance", changefreq: "daily", priority: 0.8 },
   { path: "/governance/drep", changefreq: "daily", priority: 0.7 },
   { path: "/api-docs", changefreq: "monthly", priority: 0.6 },
@@ -191,4 +204,85 @@ export function buildJsonLd(pathname: string): Record<string, any>[] {
   };
 
   return [organization, website, application];
+}
+
+/**
+ * A fully-resolved SEO override a page can return from its data fetcher as
+ * `pageProps.seo`. `_app.tsx` renders it through {@link Metatags} *outside* the
+ * `ssr:false` boundary, so dynamic pages (e.g. blog posts) get a server-rendered
+ * `<head>` with per-page title, description, OG image and JSON-LD.
+ */
+export type PageSeo = {
+  title: string;
+  description: string;
+  keywords?: string;
+  /** Site-relative OG image path. */
+  image?: string;
+  /** Open Graph object type, e.g. "article". */
+  type?: string;
+  noindex?: boolean;
+  /** Extra JSON-LD blocks appended to the site-wide ones (e.g. Article). */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  jsonLd?: Record<string, any>[];
+};
+
+/** Front-matter metadata for a blog post, shared between the data layer and pages. */
+export type ArticleMeta = {
+  slug: string;
+  title: string;
+  description: string;
+  /** ISO date (YYYY-MM-DD) the post was published. */
+  date: string;
+  /** ISO date the post was last updated; defaults to `date`. */
+  updated?: string;
+  tags?: string[];
+  /** Site-relative social image; defaults to the site OG image. */
+  image?: string;
+  author?: string;
+};
+
+/** Default byline for blog posts. */
+export const BLOG_AUTHOR = "Mesh";
+
+/** schema.org/Article structured data for a single post. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function buildArticleJsonLd(meta: ArticleMeta): Record<string, any> {
+  const url = absoluteUrl(`/blog/${meta.slug}`);
+  return {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: meta.title,
+    description: meta.description,
+    image: absoluteUrl(meta.image ?? OG_IMAGE_PATH),
+    datePublished: meta.date,
+    dateModified: meta.updated ?? meta.date,
+    author: {
+      "@type": "Organization",
+      name: meta.author ?? BLOG_AUTHOR,
+      url: SITE_URL,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      logo: {
+        "@type": "ImageObject",
+        url: absoluteUrl("/favicon/apple-touch-icon.png"),
+      },
+    },
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    ...(meta.tags?.length ? { keywords: meta.tags.join(", ") } : {}),
+  };
+}
+
+/** Build the resolved {@link PageSeo} override for a blog post. */
+export function buildPostSeo(meta: ArticleMeta): PageSeo {
+  return {
+    title: `${meta.title} · ${SITE_NAME}`,
+    description: meta.description,
+    keywords: meta.tags?.length ? meta.tags.join(", ") : DEFAULT_KEYWORDS,
+    image: meta.image ?? OG_IMAGE_PATH,
+    type: "article",
+    noindex: false,
+    jsonLd: [buildArticleJsonLd(meta)],
+  };
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import { useEffect } from "react";
 import dynamic from "next/dynamic";
 
 import { env } from "@/env";
-import { getRouteSeo } from "@/lib/seo";
+import { getRouteSeo, type PageSeo } from "@/lib/seo";
 
 import { api } from "@/utils/api";
 
@@ -58,8 +58,22 @@ const MyApp: AppType<{ session: Session | null }> = ({
   // canonical / og:url tags (so dynamic routes resolve to the actual path, not
   // a "[id]" pattern).
   const router = useRouter();
-  const seo = getRouteSeo(router.pathname);
+  const routeSeo = getRouteSeo(router.pathname);
   const canonicalPath = (router.asPath || "/").split(/[?#]/)[0] || "/";
+
+  // A page can return a fully-resolved `seo` override from its data fetcher
+  // (e.g. blog posts via getServerSideProps). It's merged over the route-pattern
+  // defaults here so dynamic pages get a server-rendered, per-page <head>.
+  const pageSeo = (pageProps as { seo?: PageSeo }).seo;
+  const seo = {
+    title: pageSeo?.title ?? routeSeo.title,
+    description: pageSeo?.description ?? routeSeo.description,
+    keywords: pageSeo?.keywords ?? routeSeo.keywords,
+    noindex: pageSeo?.noindex ?? routeSeo.noindex,
+    image: pageSeo?.image,
+    type: pageSeo?.type,
+    jsonLd: pageSeo?.jsonLd,
+  };
 
   const umamiWebsiteId = env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
   const umamiScriptUrl =
@@ -76,6 +90,9 @@ const MyApp: AppType<{ session: Session | null }> = ({
         keywords={seo.keywords}
         path={canonicalPath}
         noindex={seo.noindex}
+        image={seo.image}
+        type={seo.type}
+        extraJsonLd={seo.jsonLd}
       />
       <MeshProviderNoSSR>
         {umamiWebsiteId && (

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -1,0 +1,21 @@
+import type { GetServerSideProps } from "next";
+import { getPostBySlug, type BlogPost } from "@/lib/blog";
+import { buildPostSeo } from "@/lib/seo";
+import PageBlogPost from "@/components/pages/blog/post";
+
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+  const slug = String(params?.slug ?? "");
+  const post = getPostBySlug(slug);
+  if (!post) return { notFound: true };
+
+  res.setHeader(
+    "Cache-Control",
+    "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+  );
+  // `seo` is read by _app.tsx (pageProps.seo) to render a per-post <head>.
+  return { props: { post, seo: buildPostSeo(post.meta) } };
+};
+
+export default function BlogPostPage({ post }: { post: BlogPost }) {
+  return <PageBlogPost post={post} />;
+}

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,0 +1,16 @@
+import type { GetServerSideProps } from "next";
+import type { ArticleMeta } from "@/lib/seo";
+import { getAllPostsMeta } from "@/lib/blog";
+import PageBlogIndex from "@/components/pages/blog";
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  res.setHeader(
+    "Cache-Control",
+    "public, max-age=600, s-maxage=3600, stale-while-revalidate=86400",
+  );
+  return { props: { posts: getAllPostsMeta() } };
+};
+
+export default function BlogIndexPage({ posts }: { posts: ArticleMeta[] }) {
+  return <PageBlogIndex posts={posts} />;
+}

--- a/src/pages/sitemap.xml.tsx
+++ b/src/pages/sitemap.xml.tsx
@@ -1,27 +1,47 @@
 import type { GetServerSideProps } from "next";
-import { INDEXABLE_ROUTES, SITE_URL } from "@/lib/seo";
+import { INDEXABLE_ROUTES, SITE_URL, type ArticleMeta } from "@/lib/seo";
+import { getAllPostsMeta } from "@/lib/blog";
 
 /**
- * Serves /sitemap.xml from the static, indexable route list in `@/lib/seo`.
- * Dynamic entity pages (individual DReps) are intentionally excluded — they are
- * discovered by crawlers via in-app links rather than enumerated here.
+ * Serves /sitemap.xml from the static, indexable route list in `@/lib/seo`, plus
+ * every published blog post (enumerated from `@/lib/blog`). Other dynamic entity
+ * pages (individual DReps) are intentionally excluded — they are discovered by
+ * crawlers via in-app links rather than listed here.
  */
-function buildSitemap(): string {
-  const urls = INDEXABLE_ROUTES.map(({ path, changefreq, priority }) => {
-    const loc = `${SITE_URL}${path === "/" ? "/" : path}`;
-    return [
-      "  <url>",
-      `    <loc>${loc}</loc>`,
-      `    <changefreq>${changefreq}</changefreq>`,
-      `    <priority>${priority.toFixed(1)}</priority>`,
-      "  </url>",
-    ].join("\n");
-  }).join("\n");
+function urlEntry(
+  loc: string,
+  changefreq: string,
+  priority: number,
+  lastmod?: string,
+): string {
+  return [
+    "  <url>",
+    `    <loc>${loc}</loc>`,
+    ...(lastmod ? [`    <lastmod>${lastmod}</lastmod>`] : []),
+    `    <changefreq>${changefreq}</changefreq>`,
+    `    <priority>${priority.toFixed(1)}</priority>`,
+    "  </url>",
+  ].join("\n");
+}
+
+function buildSitemap(posts: ArticleMeta[]): string {
+  const staticUrls = INDEXABLE_ROUTES.map(({ path, changefreq, priority }) =>
+    urlEntry(`${SITE_URL}${path === "/" ? "/" : path}`, changefreq, priority),
+  );
+
+  const postUrls = posts.map((p) =>
+    urlEntry(
+      `${SITE_URL}/blog/${p.slug}`,
+      "monthly",
+      0.6,
+      p.updated ?? (p.date || undefined),
+    ),
+  );
 
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-    urls,
+    [...staticUrls, ...postUrls].join("\n"),
     "</urlset>",
     "",
   ].join("\n");
@@ -30,7 +50,7 @@ function buildSitemap(): string {
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
   res.setHeader("Content-Type", "application/xml; charset=utf-8");
   res.setHeader("Cache-Control", "public, max-age=86400, s-maxage=86400");
-  res.write(buildSitemap());
+  res.write(buildSitemap(getAllPostsMeta()));
   res.end();
   return { props: {} };
 };


### PR DESCRIPTION
## Summary

Two related additions to the public site, behind one push.

### 1. "Connect your AI agent" landing section
A new section at the top of the homepage promoting the downloadable multisig skill:
- Prominent **Download skill** button + link to the developer/bot docs.
- An **animated typing prompt** cycling example agent prompts (e.g. *"Connect to my https://multisig.meshjs.dev/ wallet"*).
- Copy makes the trust model explicit: the agent **reads and drafts** but **never signs** — keys and signatures stay with you and your co-signers (a "Read & draft only" caption + a non-signing prompt).
- New reusable `Typewriter` component (SSR-safe, honors `prefers-reduced-motion`).

### 2. SEO blog at `/blog`
Markdown-based blog with two starter posts:
- *Connect an AI agent to your Cardano multisig*
- *What is Cardano multisig? A guide to M-of-N treasuries*

Wired into the existing SEO surface (`src/lib/seo.ts`):
- **Per-post server-rendered `<head>`**: each post supplies a resolved `seo` via `pageProps`, which `_app.tsx` renders outside the `ssr:false` boundary → real per-post `<title>`, description, canonical, `og:type=article`, and **Article JSON-LD**. (`Metatags` gained `image` / `type` / `extraJsonLd`.)
- Posts enumerated in **`/sitemap.xml`** with `<lastmod>`; `/blog` added to `INDEXABLE_ROUTES`.
- "Blog" added to the footer + public routes.
- Content lives in `src/content/blog/*.md`, read by a server-only data layer (`src/lib/blog.ts`) with a tiny front-matter parser — **no new dependencies** (`react-markdown` / `remark-gfm` were already present).

## Verification
- `tsc --noEmit` clean (the pre-existing, unrelated `governance.ts` Prisma errors aside).
- Production build (`next build --webpack`) succeeds; `/blog` and `/blog/[slug]` compile.
- Ran `next start` and confirmed: `/blog` → 200, both posts → 200 with correct per-post SSR'd titles + `og:type=article` + canonical, unknown slug → 404, sitemap lists both posts, no server errors.

## Notes
- Blog article **bodies render client-side** (consistent with the rest of the app, which sits inside `MeshProviderNoSSR` / `ssr:false`); the SEO-critical `<head>` is server-rendered. Full body SSR would need a provider-boundary change — happy to do that as a follow-up if wanted.
- The Claude Code preview config (`.claude/launch.json`) was intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
