### PR TITLE
fix(db): enable RLS on tables added since the original RLS migration

### DIFF
--- a/prisma/migrations/20260706100000_enable_rls_followup_tables/migration.sql
+++ b/prisma/migrations/20260706100000_enable_rls_followup_tables/migration.sql
@@ -1,0 +1,43 @@
+-- Enable Row Level Security (RLS) and deny-all policies for PostgREST roles
+-- on tables created after 20251215090000_enable_rls_disable_postgrest.
+-- Covers the Supabase security advisor's rls_disabled_in_public findings
+-- (PendingBot, BotClaimToken, AuditLog, Contact, WalletBotAccess, BotKey,
+-- BotUser) plus tables that land in the same deploy and would be flagged
+-- next (ProposalTally, notification center tables).
+--
+-- Same contract as the original migration:
+-- - Enables RLS on each table unconditionally (skipping tables that don't exist)
+-- - Only creates deny-all policies for `anon` and `authenticated` roles if they exist
+-- - Prisma (service role / table owner) continues to bypass RLS
+
+DO $$
+DECLARE
+  tbl TEXT;
+BEGIN
+  FOR tbl IN
+    SELECT unnest(ARRAY[
+      'PendingBot', 'BotClaimToken', 'BotUser', 'BotKey', 'WalletBotAccess',
+      'Contact', 'AuditLog', 'ProposalTally',
+      'WalletSignerNotificationSetting', 'EmailVerificationToken', 'NotificationDelivery'
+    ])
+  LOOP
+    -- Skip tables that don't exist
+    IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = tbl) THEN
+      EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', tbl);
+
+      IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+        EXECUTE format(
+          'CREATE POLICY "deny_all_anon_%s" ON %I FOR ALL TO anon USING (false) WITH CHECK (false)',
+          tbl, tbl
+        );
+      END IF;
+
+      IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        EXECUTE format(
+          'CREATE POLICY "deny_all_authenticated_%s" ON %I FOR ALL TO authenticated USING (false) WITH CHECK (false)',
+          tbl, tbl
+        );
+      END IF;
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Why

The Supabase security advisor reports `rls_disabled_in_public` (**ERROR** level) for seven tables in production: `PendingBot`, `BotClaimToken`, `AuditLog`, `Contact`, `WalletBotAccess`, `BotKey`, `BotUser`. All were created after [`20251215090000_enable_rls_disable_postgrest`](prisma/migrations/20251215090000_enable_rls_disable_postgrest/migration.sql), which enabled RLS + deny-all PostgREST policies on every table that existed at the time — but nothing enforces the pattern for tables added later.

This closes the July roadmap item "review the Supabase RLS advisory on the seven rls_enabled:false tables".

## What

One follow-up migration in the exact pattern of the original:

- **The 7 flagged tables**, plus the tables that will be flagged as soon as they deploy: `ProposalTally` (on `main`, deploy still pending) and the notification-center tables `WalletSignerNotificationSetting`, `EmailVerificationToken`, `NotificationDelivery` (currently preprod-only) — 11 total.
- RLS enabled unconditionally; deny-all policies for `anon`/`authenticated` created only if those roles exist; tables that don't exist are skipped. Safe on any PostgreSQL, no-op outside Supabase.
- Prisma connects as the table owner (service role) and continues to bypass RLS — no app behavior change.

Advisor reference: [rls_disabled_in_public](https://supabase.com/docs/guides/database/database-linter?lint=0013_rls_disabled_in_public)

## Note for the deploy

The `ProposalTally` migration from #303 still hasn't been applied to production (the June 17 deploy-migrations run failed pre-Node-22-fix, and nothing has re-triggered it). When this PR eventually reaches `main` it will trigger the deploy workflow and apply both. If governance tallies erroring in prod is urgent before then, dispatch **Deploy Database Migrations** manually on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)