### PR TITLE
fix(repo): remove stray .claude/worktrees gitlink, ignore worktree dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ scripts/bot-ref/bot-wallet.json
 # CI artifacts
 ci-artifacts/
 .ci-dist/
+
+# Claude Code worktrees and local session state (never commit)
+.claude/worktrees/


### PR DESCRIPTION
## Why

`.claude/worktrees/peaceful-northcutt` is committed on `main` and `preprod` as a bare **gitlink** (mode `160000`) with no `.gitmodules` entry — introduced accidentally in `dde4f56`. Every submodule-aware git operation trips on it; most visibly, `actions/checkout` post-job cleanup errors with:

```
fatal: No url found for submodule path '.claude/worktrees/peaceful-northcutt' in .gitmodules
##[warning]The process '/usr/bin/git' failed with exit code 128
```

on every recent CI run.

## What

- `git rm --cached .claude/worktrees/peaceful-northcutt` — removes the dead gitlink (no working-tree files are touched; the directory only exists on machines that created that local worktree).
- Add `.claude/worktrees/` to `.gitignore` so local Claude Code worktrees can't be committed again. Deliberately scoped to the worktrees subdirectory only, in case tracked `.claude/` config is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)