### PR TITLE
fix(governance): public DRep explorer no longer requires a connected wallet

### DIFF
--- a/src/components/pages/homepage/governance/drep/id/index.tsx
+++ b/src/components/pages/homepage/governance/drep/id/index.tsx
@@ -8,7 +8,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { Loader } from "lucide-react";
 import ActiveIndicator from "../activeIndicator";
 import ScriptIndicator from "../scriptIndicator";
-import useMeshWallet from "@/hooks/useMeshWallet";
+import usePublicNetwork from "@/hooks/usePublicNetwork";
 import RowLabelInfo from "@/components/common/row-label-info";
 import { extractJsonLdValue } from "@/utils/jsonLdParser";
 import { Button } from "@/components/ui/button";
@@ -17,33 +17,16 @@ import DelegateButton from "./delegateButton";
 export default function DrepDetailPage() {
   const router = useRouter();
   const { id } = router.query;
-  const { wallet, connected } = useMeshWallet();
   const [drepInfo, setDrepInfo] = useState<BlockfrostDrepInfo | null>(null);
   const [drepMetadata, setDrepMetadata] =
     useState<BlockfrostDrepMetadata | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
-  const [network, setNetwork] = useState<number>(3); // Default to mainnet
+  // Mainnet for anonymous visitors, the wallet's network once connected.
+  const network = usePublicNetwork();
 
-    useEffect(() => {
-      async function fetchNetwork() {
-        if (connected && wallet) {
-          try {
-            const net = await wallet.getNetworkId();
-            setNetwork(net);
-          } catch (error) {
-          setNetwork(1);
-            console.error("Error fetching network ID:", error);
-          }
-        }
-      }
-    
-      fetchNetwork();
-    }, [connected, wallet]);
-    
   useEffect(() => {
-    if (network === 3) return; // Prevent fetching if network is not set
     if (id) fetchDrepData(id as string);
-  }, [id, wallet, network]);
+  }, [id, network]);
 
   async function fetchDrepData(drepId: string) {
     setLoading(true);

--- a/src/components/pages/homepage/governance/drep/index.tsx
+++ b/src/components/pages/homepage/governance/drep/index.tsx
@@ -4,7 +4,7 @@ import Pagination from "@/components/common/overall-layout/pagination";
 import { getProvider } from "@/utils/get-provider";
 import { BlockfrostDrepInfo, BlockfrostDrepMetadata } from "@/types/governance";
 import Link from "next/link";
-import useMeshWallet from "@/hooks/useMeshWallet";
+import usePublicNetwork from "@/hooks/usePublicNetwork";
 import DelegateButton from "./id/delegateButton";
 import RowLabelInfo from "@/components/common/row-label-info";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -16,33 +16,15 @@ export default function DrepOverviewPage() {
     Array<{ details: BlockfrostDrepInfo; metadata: BlockfrostDrepMetadata | null }>
   >([]);
   const [loading, setLoading] = useState<boolean>(true);
-  const { wallet, connected } = useMeshWallet();
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [pageSize, setPageSize] = useState<number>(25);
   const [order, setOrder] = useState<"asc" | "desc">("asc");
   const [isLastPage, setIsLastPage] = useState<boolean>(false);
-  const [network, setNetwork] = useState<number>(3); // Default to mainnet
+  // Mainnet for anonymous visitors, the wallet's network once connected.
+  const network = usePublicNetwork();
 
   useEffect(() => {
-    async function fetchNetwork() {
-      if (connected && wallet) {
-        try {
-          const net = await wallet.getNetworkId();
-          setNetwork(net);
-        } catch (error) {
-        setNetwork(1);
-          console.error("Error fetching network ID:", error);
-        }
-      }
-    }
-  
-    fetchNetwork();
-  }, [connected, wallet]);
-  
-  useEffect(() => {
     async function loadDrepList() {
-      if (network === 3) return; // Prevent fetching if network is not set
-  
       setLoading(true);
       const blockchainProvider = getProvider(network);
   
@@ -73,10 +55,8 @@ export default function DrepOverviewPage() {
       }
     }
   
-    if (network !== null) {
-      loadDrepList();
-    }
-  }, [currentPage, pageSize, order, network]); // Dependency now waits for network
+    loadDrepList();
+  }, [currentPage, pageSize, order, network]);
 
   // Fetch DRep details
   const fetchDrepDetails = async (drepId: string) => {

--- a/src/hooks/usePublicNetwork.ts
+++ b/src/hooks/usePublicNetwork.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import useMeshWallet from "@/hooks/useMeshWallet";
+
+/**
+ * Network id (0 = preprod, 1 = mainnet) for public, no-login pages.
+ *
+ * Defaults to mainnet so anonymous visitors get data immediately; when a
+ * wallet connects, switches to that wallet's network. Public explorers used
+ * to park on a "not yet known" sentinel until a wallet reported its network,
+ * which left visitors without a wallet on an endless spinner.
+ */
+export default function usePublicNetwork(): number {
+  const { wallet, connected } = useMeshWallet();
+  const [network, setNetwork] = useState<number>(1);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (connected && wallet) {
+      wallet
+        .getNetworkId()
+        .then((net) => {
+          if (!cancelled) setNetwork(net);
+        })
+        .catch((error) => {
+          console.error("Error fetching network ID:", error);
+          if (!cancelled) setNetwork(1);
+        });
+    } else {
+      setNetwork(1);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [connected, wallet]);
+
+  return network;
+}


### PR DESCRIPTION
## Problem

The public DRep explorer pages (`/governance/drep` and `/governance/drep/[id]`) hang on an endless spinner for visitors without a connected Cardano wallet: `network` was initialized to the sentinel value 3 and only a connected wallet's `getNetworkId()` could clear it, so the data-fetch effects early-returned forever.

## Fix

- New `usePublicNetwork` hook: defaults to mainnet (1) immediately, switches to the wallet's network once one connects, falls back to mainnet on errors/disconnect.
- Both DRep pages use it; the duplicated `fetchNetwork` blocks and `network === 3` guards are removed, so data loads on first render.

## Verification

- Typecheck + full jest suite pass (449 tests, both module modes).
- Production build exercised in a browser with **no wallet extension** (the previously broken case): the list renders mainnet DReps and the detail page renders full DRep info, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)