### PR TITLE
fix(ux): DRep explorer light-mode readability + no hero CTA in page headers

### DIFF
--- a/src/components/common/cardano-objects/connect-wallet.tsx
+++ b/src/components/common/cardano-objects/connect-wallet.tsx
@@ -25,8 +25,20 @@ import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { useWalletDetection } from "@/hooks/useWalletDetection";
 
+/**
+ * Where the connector may render the large "Get Started with UTXOS" call to
+ * action when no wallet extension is installed. "hero" (homepage hero) keeps
+ * it; "compact" (page headers) always renders the regular pill button whose
+ * dropdown already leads no-extension users to UTXOS.
+ */
+export type ConnectWalletVariant = "hero" | "compact";
+
 // Main component - uses walletDetectionKey to force remount of useWalletList
-export default function ConnectWallet() {
+export default function ConnectWallet({
+  variant = "hero",
+}: {
+  variant?: ConnectWalletVariant;
+} = {}) {
   // Force re-mount key for useWalletList when wallets are detected
   const [walletDetectionKey, setWalletDetectionKey] = useState(0);
   const hasTriggeredRemountRef = useRef(false);
@@ -64,17 +76,24 @@ export default function ConnectWallet() {
     };
   }, []);
 
-  return <ConnectWalletInner key={walletDetectionKey} />;
+  return <ConnectWalletInner key={walletDetectionKey} variant={variant} />;
 }
 
 // Internal component that uses useWalletList - will remount when key changes
-function ConnectWalletInner() {
+function ConnectWalletInner({ variant }: { variant: ConnectWalletVariant }) {
   const wallets = useWalletList();
   const networkId = useNetwork();
   const assets = useAssets();
-  
-  
-  return <ConnectWalletContent wallets={wallets} networkId={networkId} assets={assets} />;
+
+
+  return (
+    <ConnectWalletContent
+      wallets={wallets}
+      networkId={networkId}
+      assets={assets}
+      variant={variant}
+    />
+  );
 }
 
 // Main component content
@@ -82,10 +101,12 @@ function ConnectWalletContent({
   wallets,
   networkId,
   assets,
+  variant,
 }: {
   wallets: ReturnType<typeof useWalletList>;
   networkId: ReturnType<typeof useNetwork>;
   assets: ReturnType<typeof useAssets>;
+  variant: ConnectWalletVariant;
 }) {
   const setNetwork = useSiteStore((state) => state.setNetwork);
   const pastUtxosEnabled = useUserStore((state) => state.pastUtxosEnabled);
@@ -695,13 +716,15 @@ function ConnectWalletContent({
 
   // No Cardano wallet extension installed (detection has settled) and nothing
   // connected yet: lead non-crypto users straight to UTXOS instead of a picker.
+  // Only the hero placement (homepage) gets the large CTA — in page headers
+  // the compact pill + dropdown stays, which offers UTXOS as well.
   const noWalletDetected =
     !forceMenu &&
     !detectingWallets &&
     wallets.length === 0 &&
     !isAnyWalletConnected;
 
-  if (noWalletDetected) {
+  if (noWalletDetected && variant === "hero") {
     return (
       <div className="flex flex-col items-center gap-2">
         <Button

--- a/src/components/common/overall-layout/layout.tsx
+++ b/src/components/common/overall-layout/layout.tsx
@@ -656,7 +656,9 @@ export default function RootLayout({
               {!isLoggedIn ? (
                 // On the homepage, the hero renders the wallet connector (avoid double-mount).
                 // On all other routes, show it in the header.
-                isHomepage ? null : <ConnectWallet key="wallet-connector" />
+                isHomepage ? null : (
+                  <ConnectWallet key="wallet-connector" variant="compact" />
+                )
               ) : (
                 <>
                   {/* Desktop buttons */}

--- a/src/components/pages/homepage/governance/drep/id/index.tsx
+++ b/src/components/pages/homepage/governance/drep/id/index.tsx
@@ -64,14 +64,14 @@ export default function DrepDetailPage() {
   if (loading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <Loader className="h-8 w-8 animate-spin text-gray-500" />
+        <Loader className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     );
   }
 
   if (!drepInfo) {
     return (
-      <p className="text-center text-gray-500">DRep data is unavailable.</p>
+      <p className="text-center text-muted-foreground">DRep data is unavailable.</p>
     );
   }
 
@@ -92,7 +92,7 @@ export default function DrepDetailPage() {
 
   return (
     <TooltipProvider>
-      <main className="flex flex-col gap-4 p-4 text-gray-300 md:p-8">
+      <main className="flex flex-col gap-4 p-4 text-foreground md:p-8">
         
         {/*  Top Action Buttons */}
         <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
@@ -116,7 +116,7 @@ export default function DrepDetailPage() {
               />
             ) : (
               <svg
-                className="h-24 w-24 sm:h-32 sm:w-32 text-gray-500"
+                className="h-24 w-24 sm:h-32 sm:w-32 text-muted-foreground"
                 fill="none"
                 stroke="currentColor"
                 strokeWidth="2"
@@ -134,7 +134,7 @@ export default function DrepDetailPage() {
             {/* Name, Status, and Indicators */}
             <div className="flex flex-wrap items-center space-x-2">
               <ActiveIndicator isActive={active} />
-              <span className="text-lg font-semibold text-gray-200">{givenName}</span>
+              <span className="text-lg font-semibold text-foreground">{givenName}</span>
               {has_script && <ScriptIndicator hasScript={has_script} />}
             </div>
 
@@ -143,7 +143,7 @@ export default function DrepDetailPage() {
               label="DRep ID:"
               value={drep_id}
               copyString={drep_id}
-              className="truncate sm:whitespace-nowrap break-all text-sm text-gray-400"
+              className="truncate sm:whitespace-nowrap break-all text-sm text-muted-foreground"
             />
 
             {/* Payment Address */}
@@ -151,13 +151,13 @@ export default function DrepDetailPage() {
               label="Address:"
               value={paymentAddress}
               copyString={paymentAddress}
-              className="truncate sm:whitespace-nowrap break-all text-sm text-gray-400"
+              className="truncate sm:whitespace-nowrap break-all text-sm text-muted-foreground"
             />
           </div>
 
           {/* ADA Amount */}
           <div className="flex-shrink-0 sm:text-right text-center w-full sm:w-auto">
-            <p className="text-lg font-semibold text-gray-300">{adaAmount}</p>
+            <p className="text-lg font-semibold text-foreground">{adaAmount}</p>
           </div>
         </div>
 

--- a/src/components/pages/homepage/governance/drep/id/metadata.tsx
+++ b/src/components/pages/homepage/governance/drep/id/metadata.tsx
@@ -17,7 +17,7 @@ export default function Metadata({
 }) {
   if (!drepMetadata) {
     return (
-      <p className="text-center text-gray-500">
+      <p className="text-center text-muted-foreground">
         No metadata available for this DRep.
       </p>
     );
@@ -82,13 +82,13 @@ export default function Metadata({
 
   //  Icon Mapping for Social Media
   const iconMap: Record<string, React.ReactElement> = {
-    "x.com": <Twitter className="h-7 w-7 text-gray-200 hover:text-blue-400" />,
+    "x.com": <Twitter className="h-7 w-7 text-muted-foreground transition-colors hover:text-blue-500" />,
     "twitter.com": (
-      <Twitter className="h-7 w-7 text-gray-200 hover:text-blue-400" />
+      <Twitter className="h-7 w-7 text-muted-foreground transition-colors hover:text-blue-500" />
     ),
     "discord.gg": (
       <svg
-        className="h-7 w-7 text-gray-200 hover:text-blue-400"
+        className="h-7 w-7 text-muted-foreground transition-colors hover:text-blue-500"
         fill="currentColor"
         viewBox="0 0 16 16"
         aria-hidden="true"
@@ -105,7 +105,7 @@ export default function Metadata({
     ),
     "github.com": (
       <svg
-        className="h-7 w-7 text-gray-200 hover:text-blue-400"
+        className="h-7 w-7 text-muted-foreground transition-colors hover:text-blue-500"
         fill="currentColor"
         viewBox="0 0 24 24"
         aria-hidden="true"
@@ -153,7 +153,7 @@ export default function Metadata({
                   rel="noopener noreferrer"
                 >
                   {iconMap[social.domain] || (
-                    <LinkIcon className="h-5 w-5 text-gray-400" />
+                    <LinkIcon className="h-5 w-5 text-muted-foreground" />
                   )}
                 </a>
               ))}
@@ -185,10 +185,10 @@ export default function Metadata({
         {/*  Metadata Details */}
         <div >
           <h3 className="text-lg font-semibold">Metadata Details</h3>
-          <p>
+          <p className="break-all">
             <strong>Metadata Hex:</strong> {metadataHex}
           </p>
-          <p>
+          <p className="break-all">
             <strong>Metadata Hash:</strong> {metadataHash}
           </p>
           <p className="text-muted-foreground">

--- a/src/components/pages/homepage/governance/drep/index.tsx
+++ b/src/components/pages/homepage/governance/drep/index.tsx
@@ -94,7 +94,7 @@ export default function DrepOverviewPage() {
 
   return (
     <TooltipProvider>
-      <main className="flex flex-col gap-8 p-4 text-gray-300 md:p-8">
+      <main className="flex flex-col gap-8 p-4 text-foreground md:p-8">
         <SectionTitle>DREP Overview</SectionTitle>
 
         {/* Pagination Component */}
@@ -131,7 +131,7 @@ export default function DrepOverviewPage() {
               return (
                 <div
                   key={drepId}
-                  className="flex items-center gap-4 rounded-lg border-y border-gray-700 p-4 shadow-sm"
+                  className="flex flex-wrap items-center gap-4 rounded-lg border-y border-border p-4 shadow-sm"
                 >
                   {/* Profile Image or Placeholder */}
                   {imageUrl ? (
@@ -142,7 +142,7 @@ export default function DrepOverviewPage() {
                     />
                   ) : (
                     <svg
-                      className="h-12 w-12 text-gray-500"
+                      className="h-12 w-12 text-muted-foreground"
                       fill="none"
                       stroke="currentColor"
                       strokeWidth="2"
@@ -155,12 +155,16 @@ export default function DrepOverviewPage() {
                   )}
 
                   {/* DRep Info */}
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex min-w-0 items-center gap-2">
                       <ActiveIndicator isActive={isActive} />
                       {/* DRep Name */}
-                      <Link href={`/governance/drep/${drepId}`} passHref>
-                        <div className="cursor-pointer text-lg font-semibold text-gray-200 hover:underline">
+                      <Link
+                        href={`/governance/drep/${drepId}`}
+                        passHref
+                        className="min-w-0"
+                      >
+                        <div className="cursor-pointer truncate text-lg font-semibold text-foreground hover:underline">
                           {givenName}
                         </div>
                       </Link>
@@ -168,16 +172,11 @@ export default function DrepOverviewPage() {
                     </div>
 
                     {/* DRep ID directly under name */}
-                    <RowLabelInfo
-                      label="DRep ID:"
-                      value={drepId}
-                      copyString={drepId}
-                      className="text-sm text-gray-400"
-                    />
+                    <RowLabelInfo label="DRep ID:" value={drepId} copyString={drepId} />
                   </div>
 
                   {/* ADA Amount (Larger, Aligned Right) */}
-                  <p className="text-lg font-semibold text-gray-300">
+                  <p className="flex-shrink-0 whitespace-nowrap text-lg font-semibold text-foreground">
                     {adaAmount}
                   </p>
 
@@ -189,7 +188,7 @@ export default function DrepOverviewPage() {
           )}
 
           {!loading && drepList.length === 0 && (
-            <p className="text-gray-500">No DREP information available.</p>
+            <p className="text-muted-foreground">No DREP information available.</p>
           )}
         </div>
       </main>


### PR DESCRIPTION
## What

Two UX fixes for the public explorer surfaces:

1. **Light-mode readability**: the DRep list/detail pages hardcoded dark-theme grays (`text-gray-200/300/400/500`, `border-gray-700`), leaving headings, names, ids and balances nearly invisible on light backgrounds. Swapped for the app's theme tokens (`text-foreground` / `text-muted-foreground` / `border-border`). Also fixed row overflow: long DRep ids forced rows wider than the container and clipped the Delegate buttons — rows now wrap and the info column truncates with an ellipsis; long metadata hex/hash strings break instead of overflowing.

2. **Header CTA**: when no wallet extension was detected, `ConnectWallet` swapped itself for the hero-sized "Get Started with Multisig using UTXOS" button wherever it rendered — including the header of every public page, stacked over the top bar. New `variant` prop: the homepage hero keeps the large CTA (default), the layout header renders `compact` — the regular Connect Wallet pill whose dropdown already leads no-extension users to UTXOS (marked Recommended).

## Verification

Production build checked in the browser in both color schemes: light mode renders crisp text with truncated ids and intact Delegate buttons; dark mode unchanged. Header shows the compact pill on explorer pages; its dropdown retains the full UTXOS onboarding path; homepage hero CTA unchanged. Typecheck + full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)