### PR TITLE
fix(bots): observer access is enough to draft ballots

### DIFF
--- a/src/__tests__/botBallotsUpsert.test.ts
+++ b/src/__tests__/botBallotsUpsert.test.ts
@@ -140,11 +140,37 @@ beforeEach(() => {
     id: "bot-1",
     botKey: { scope: JSON.stringify(["multisig:read", "ballot:write"]) },
   });
-  assertBotWalletAccessMock.mockResolvedValue({ wallet: { id: "wallet-1" }, role: "cosigner" });
+  // Observer role suffices for ballot drafting (unsigned advisory rows).
+  assertBotWalletAccessMock.mockResolvedValue({ wallet: { id: "wallet-1" }, role: "observer" });
   transactionMock.mockImplementation(async (cb: any) => cb(txMock));
 });
 
 describe("botBallotsUpsert API", () => {
+  it("requests non-mutating wallet access (observer role is enough to draft)", async () => {
+    const req = {
+      method: "POST",
+      headers: { authorization: "Bearer token" },
+      body: {
+        walletId: "wallet-1",
+        ballotName: "Advisory",
+        proposals: [{ proposalId: "a".repeat(64) + "#0", proposalTitle: "T", choice: "Yes" }],
+      },
+    } as unknown as NextApiRequest;
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    // The access assertion must be called with mutating=false — cosigner must
+    // NOT be required for advisory drafts.
+    expect(assertBotWalletAccessMock as jest.Mock).toHaveBeenCalledWith(
+      expect.anything(),
+      "wallet-1",
+      expect.anything(),
+      false,
+    );
+    expect(res.status).not.toHaveBeenCalledWith(403);
+  });
+
   it("rejects anchor fields in proposal payload", async () => {
     const req = {
       method: "POST",

--- a/src/pages/api/v1/README.md
+++ b/src/pages/api/v1/README.md
@@ -231,7 +231,7 @@ Endpoints:
 - **Purpose**: Create/update governance ballots with bot vote decisions and draft rationale comments
 - **Authentication**: Required (bot JWT Bearer token)
 - **Scope**: `ballot:write`
-- **Wallet Access**: Requires bot `cosigner` role for `walletId`
+- **Wallet Access**: Any granted role for `walletId` — **observer is enough** (ballot drafts are unsigned advisory rows; bots cannot set anchors)
 - **Features**:
   - Deterministic ballot target resolution (`ballotId` preferred, `ballotName` fallback)
   - `409` on ambiguous `ballotName` matches

--- a/src/pages/api/v1/botBallotsUpsert.ts
+++ b/src/pages/api/v1/botBallotsUpsert.ts
@@ -121,7 +121,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    await assertBotWalletAccess(db, walletId, payload, true);
+    // Non-mutating access: ballot drafts are unsigned advisory rows (choice +
+    // rationaleComment only — anchors are rejected below), so an observer
+    // grant is enough. Cosigner-for-drafts would lock advisory bots out of
+    // existing wallets entirely, since signer lists are fixed at creation.
+    // The ballot:write scope (owner-approved at claim) still gates this.
+    await assertBotWalletAccess(db, walletId, payload, false);
   } catch (err) {
     return res
       .status(403)

--- a/src/utils/swagger.ts
+++ b/src/utils/swagger.ts
@@ -1651,7 +1651,7 @@ This API uses **Bearer Token** authentication (JWT).
           tags: ["V1", "Bot", "Governance"],
           summary: "Create or update governance ballots from bot decisions",
           description:
-            "Upserts proposals and vote choices into a governance ballot (type=1). Bots may only submit rationaleComment drafts; anchorUrl/anchorHash are rejected. Requires bot JWT, ballot:write scope, and cosigner wallet access.",
+            "Upserts proposals and vote choices into a governance ballot (type=1). Bots may only submit rationaleComment drafts; anchorUrl/anchorHash are rejected. Requires bot JWT, ballot:write scope, and any granted wallet access — observer is enough (drafts are unsigned advisory rows; the wallet owner grants access under User → Bot Management → Wallet access).",
           requestBody: {
             required: true,
             content: {


### PR DESCRIPTION
## Problem

`botBallotsUpsert` required the **cosigner** role, but the UI only allows cosigner grants when the bot's payment address is in the wallet's signer list — which is fixed at wallet creation. Net effect: an advisory bot (the whole point of the `ballot:write` scope) could never draft ballots on any existing wallet. Observed live by the drep-collective bot: `403 "Bot not allowed for this wallet"` with no grantable path to fix it.

## Fix

Ballot drafting now requires any granted wallet role — **observer suffices** — plus the `ballot:write` scope the owner approved at claim (still a double opt-in). Drafts remain unsigned advisory rows: the endpoint only accepts `choice` + `rationaleComment` and continues to reject `anchorUrl`/`anchorHash` from bots.

Docs updated (OpenAPI, v1 README); a new test pins the non-mutating access requirement so cosigner-for-drafts can't silently return.

## Verification

Typecheck + full suite pass (533 tests across both jest modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)