### PR TITLE
feat(ui): bot accounts card on the wallets dashboard

### DIFF
--- a/src/components/pages/homepage/wallets/index.tsx
+++ b/src/components/pages/homepage/wallets/index.tsx
@@ -25,6 +25,7 @@ import SectionExplanation from "./SectionExplanation";
 import WalletCardSkeleton from "./WalletCardSkeleton";
 import WalletInviteCardSkeleton from "./WalletInviteCardSkeleton";
 import IPFSImage from "@/components/common/ipfs-image";
+import BotManagementCard from "@/components/pages/user/BotManagementCard";
 
 
 export default function PageWallets() {
@@ -234,6 +235,10 @@ export default function PageWallets() {
             </div>
           </>
         )}
+
+        {/* Claim and manage API bots without leaving the dashboard — the same
+            card as on the user page (it renders its own title and actions). */}
+        <BotManagementCard />
       </>
     </div>
   );


### PR DESCRIPTION
Claiming a bot previously required knowing the card lives on the user profile page. The same self-contained `BotManagementCard` (claim flow, scopes editor, wallet grants with the new at-a-glance view) now also renders at the bottom of the logged-in home dashboard, below the wallet sections — so claim → grant → revoke is reachable right from the Wallets page.

Zero component changes — pure reuse, so both placements stay in sync automatically.

## Verification
Typecheck, full suite (546 tests), and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)