### PR TITLE
fix(roadmap): render the feature graph per request, not at build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,6 +42,10 @@ Thumbs.db
 # Documentation
 *.md
 !README.md
+# The feature vault is data, not documentation: /roadmap/graph reads these notes
+# at runtime, so they have to survive the *.md filter above.
+!vault
+!vault/**
 docs
 
 # Docker

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -174,9 +174,9 @@ function readNotes(dir: string): { title: string; raw: string }[] {
 
 /**
  * Build the graph. Throws when a feature names an area or state that has no note,
- * so a typo surfaces at build time instead of silently dropping an edge.
+ * so a typo surfaces on the first read instead of silently dropping an edge.
  */
-export function loadVaultGraph(): VaultGraph {
+function buildVaultGraph(): VaultGraph {
   const nodes: VaultNode[] = [];
   const edges: VaultEdge[] = [];
 
@@ -279,4 +279,19 @@ export function loadVaultGraph(): VaultGraph {
   );
 
   return { nodes, edges, counts, generatedFrom: "vault/" };
+}
+
+let cached: VaultGraph | null = null;
+
+/**
+ * The graph, parsed once per process.
+ *
+ * The vault is immutable inside a deployed container, so re-reading ~66 files on
+ * every request would be pure waste. In development the cache is skipped, so
+ * editing a note and refreshing shows the change without a restart.
+ */
+export function loadVaultGraph(): VaultGraph {
+  if (process.env.NODE_ENV !== "production") return buildVaultGraph();
+  cached ??= buildVaultGraph();
+  return cached;
 }

--- a/src/pages/roadmap/graph.tsx
+++ b/src/pages/roadmap/graph.tsx
@@ -1,20 +1,26 @@
-import type { InferGetStaticPropsType } from "next";
+import type { InferGetServerSidePropsType } from "next";
 
 import { VaultGraphView } from "@/components/pages/homepage/roadmap/graph";
 import { loadVaultGraph } from "@/lib/vault";
 
 /**
- * The vault is a folder of files that only changes when the repo does, so it is
- * read once at build time rather than on every request. This is the one page in
- * the app using `getStaticProps` instead of a no-op `getServerSideProps`, and the
- * reason is that: no runtime filesystem access, and a malformed note fails the
- * build rather than a visitor's request.
+ * Read the vault per request, like every other page here.
+ *
+ * This originally used `getStaticProps` — the vault only changes when the repo
+ * does, so parsing it once at build time was cheaper. That made Next *prerender*
+ * the page, which fails: the app is a client-only SPA whose shell calls
+ * `useRouter` outside a mounted router, so the export step dies with
+ * "NextRouter was not mounted". It survived a local build and broke the Railway
+ * one, which is exactly the kind of difference not worth fighting.
+ *
+ * The parse is memoised in {@link loadVaultGraph}, so per-request cost is one
+ * read per process rather than one per visitor.
  */
-export const getStaticProps = () => ({ props: { graph: loadVaultGraph() } });
+export const getServerSideProps = () => ({ props: { graph: loadVaultGraph() } });
 
 export default function Page({
   graph,
-}: InferGetStaticPropsType<typeof getStaticProps>) {
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <div className="relative z-20 mx-auto w-full min-w-0 max-w-7xl py-10 lg:py-8">
       <div className="px-8">


### PR DESCRIPTION
**The preprod deploy of `a336539` failed and preprod has been serving a stale build since.** The site is up — `/` and `/features` return 200 — but it is the pre-merge build, so `/roadmap` and `/roadmap/graph` 404.

## Cause

```
Error: NextRouter was not mounted.
Error occurred prerendering page "/roadmap/graph"
Export encountered an error on /roadmap/graph, exiting the build.
```

`/roadmap/graph` used `getStaticProps`, which makes Next **prerender** the page at build time. This app is a client-only SPA whose shell calls `useRouter` outside a mounted router, so the export step dies.

Every other page in the app uses a no-op `getServerSideProps` — precisely because the shell isn't prerender-safe. This page was the one deviation, and the deviation is what broke. I flagged it as a deliberate deviation in the original commit message; that call was wrong.

Worth noting it **survived a local build**: `npm run build` is `next build --webpack`, the same command Railway runs, and it prerendered `/roadmap/graph` fine locally — including on a clean build with `.next` removed. Rather than chase a builder-environment difference, the page now follows the app's convention.

## Changes

- `getStaticProps` → `getServerSideProps` on `/roadmap/graph`.
- `loadVaultGraph` is memoised — once per process in production, uncached in development so editing a note and refreshing still works. Per-request parsing of ~66 files would otherwise be waste.
- `vault/` re-included in `.dockerignore`. Build-time parsing tolerated the blanket `*.md` filter; runtime parsing does not, and a missing vault would render an *empty* graph rather than fail loudly.

## Verification

On a clean build (`rm -rf .next && npm run build`):

- `/roadmap/graph` is now `ƒ` (server-rendered on demand) instead of `●` (prerendered), so the export step that crashed no longer runs
- serves 200, with all **52 feature nodes** in the payload
- 514 unit tests pass, no typecheck errors in the changed files

Once this merges, the preprod deploy should go green and both pages come up.