### PR TITLE
fix(build): drop the !vault/** glob that broke the Railpack build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -43,9 +43,11 @@ Thumbs.db
 *.md
 !README.md
 # The feature vault is data, not documentation: /roadmap/graph reads these notes
-# at runtime, so they have to survive the *.md filter above.
+# at runtime, so they have to survive the *.md filter above. Keep this as the
+# bare directory — Railpack turns each negation into a literal copy instruction,
+# and a `!vault/**` glob becomes `copy /vault/** /app/**`, which buildkit rejects
+# with "cannot copy to non-directory". `!vault` alone copies the tree recursively.
 !vault
-!vault/**
 docs
 
 # Docker


### PR DESCRIPTION
**The preprod build of `629a652` failed.** One line, my fault, from the fix in #351.

```
copy /vault/** /app/**
Build Failed: cannot copy to non-directory:
  /var/lib/buildkit/runc-overlayfs/cachemounts/buildkit243538423/app/**
```

## Cause

Railpack turns each `.dockerignore` negation into a literal copy instruction. Both of mine appear in the build log:

| Negation | Generated instruction | Result |
|---|---|---|
| `!vault` | `copy /vault /app/vault` | ✅ correct, recursive |
| `!vault/**` | `copy /vault/** /app/**` | ❌ buildkit takes `**` literally |

I added the glob as belt-and-braces on top of `!vault`, not knowing Railpack would emit it verbatim. It was redundant — the bare directory negation already copies the tree recursively, as the log confirms. This PR removes the glob and leaves the working directive, with a comment so nobody re-adds it.

## Note on verification

This class of failure is not reproducible locally: `next build` doesn't read `.dockerignore` at all, and the failure is in Railpack's plan generation. The only real check is the Railway build itself, so I'd watch this one through rather than assume it's green.

Everything else from #351 stands — `/roadmap/graph` is server-rendered per request and no longer prerendered.