### PR TITLE
MCP: connection management, governance tools, vendor-neutral setup

### DIFF
--- a/jest.shared.mjs
+++ b/jest.shared.mjs
@@ -34,6 +34,7 @@ export const ESM_TESTS = [
   'apiSecurity',
   'botBallotsUpsert',
   'governanceActiveProposals',
+  'mcpConnections',
   'og',
   'pendingTransactions',
   'reviewSignersCardKey',

--- a/src/__tests__/mcpConnections.test.ts
+++ b/src/__tests__/mcpConnections.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+/**
+ * The MCP connections router — listing and revoking OAuth grants from the
+ * profile page. The revoke path is an authorization boundary: it must act only
+ * on grants belonging to the wallet session making the request.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type AnyAsyncMock = jest.Mock<(...args: any[]) => any>;
+
+const grantFindMany = jest.fn() as AnyAsyncMock;
+const grantFindUnique = jest.fn() as AnyAsyncMock;
+const grantDelete = jest.fn() as AnyAsyncMock;
+const clientFindMany = jest.fn() as AnyAsyncMock;
+const tokenFindMany = jest.fn() as AnyAsyncMock;
+const tokenUpdateMany = jest.fn() as AnyAsyncMock;
+const transaction = jest.fn() as AnyAsyncMock;
+const auditMock = jest.fn() as AnyAsyncMock;
+
+// ESM-mode mocking: this suite imports the tRPC router, which pulls superjson —
+// ESM-only, and unusable in the CJS jest project. Registered in ESM_TESTS.
+jest.unstable_mockModule("@/lib/observability/audit", () => ({
+  __esModule: true,
+  audit: auditMock,
+}));
+
+const ADDR = "addr1qpuser";
+const OTHER = "addr1qpsomeoneelse";
+
+function ctx(session: { primaryWallet?: string | null; sessionWallets?: string[] }) {
+  // protectedProcedure gates on a non-empty sessionWallets (src/server/api/trpc.ts),
+  // and the real context always sets both together, so mirror that here.
+  const sessionWallets =
+    session.sessionWallets ?? (session.primaryWallet ? [session.primaryWallet] : []);
+  return {
+    ...session,
+    sessionWallets,
+    db: {
+      oAuthGrant: {
+        findMany: grantFindMany,
+        findUnique: grantFindUnique,
+        delete: grantDelete,
+      },
+      oAuthClient: { findMany: clientFindMany },
+      oAuthRefreshToken: { findMany: tokenFindMany, updateMany: tokenUpdateMany },
+      $transaction: transaction,
+    },
+  };
+}
+
+let caller: (c: unknown) => any;
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  transaction.mockImplementation(async (ops: unknown[]) => [undefined, { count: 2 }]);
+  grantDelete.mockResolvedValue({});
+  tokenUpdateMany.mockResolvedValue({ count: 2 });
+  const { mcpRouter } = await import("@/server/api/routers/mcp");
+  caller = (c) => (mcpRouter as any).createCaller(c);
+});
+
+describe("listConnections", () => {
+  it("returns nothing when the address has approved no clients", async () => {
+    grantFindMany.mockResolvedValue([]);
+    const out = await caller(ctx({ primaryWallet: ADDR })).listConnections({
+      requesterAddress: ADDR,
+    });
+    expect(out).toEqual([]);
+    // No point querying clients or tokens when there are no grants.
+    expect(clientFindMany).not.toHaveBeenCalled();
+  });
+
+  it("joins client metadata and counts only live sessions", async () => {
+    grantFindMany.mockResolvedValue([
+      {
+        id: "g1",
+        clientId: "https://claude.ai/oauth/x",
+        subjectAddress: ADDR,
+        scopes: ["wallets:read"],
+        grantedAddresses: [ADDR],
+        createdAt: new Date("2026-01-01"),
+        updatedAt: new Date("2026-01-02"),
+      },
+    ]);
+    clientFindMany.mockResolvedValue([
+      { clientId: "https://claude.ai/oauth/x", clientName: "Claude Code", clientUri: null, isMetadataUrl: true },
+    ]);
+    tokenFindMany.mockResolvedValue([
+      { clientId: "https://claude.ai/oauth/x", expiresAt: new Date(Date.now() + 60_000) },
+      // Expired: still unrevoked in the DB, but must not count as active.
+      { clientId: "https://claude.ai/oauth/x", expiresAt: new Date(Date.now() - 60_000) },
+    ]);
+
+    const [conn] = await caller(ctx({ primaryWallet: ADDR })).listConnections({
+      requesterAddress: ADDR,
+    });
+
+    expect(conn).toMatchObject({
+      clientName: "Claude Code",
+      isMetadataUrl: true,
+      scopes: ["wallets:read"],
+      activeSessions: 1,
+    });
+  });
+
+  it("scopes the query to the session address", async () => {
+    grantFindMany.mockResolvedValue([]);
+    await caller(ctx({ primaryWallet: ADDR })).listConnections({ requesterAddress: ADDR });
+    expect(grantFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { subjectAddress: ADDR } }),
+    );
+  });
+
+  it("labels a client the AS has no record of", async () => {
+    grantFindMany.mockResolvedValue([
+      {
+        id: "g1", clientId: "gone", subjectAddress: ADDR, scopes: [], grantedAddresses: [ADDR],
+        createdAt: new Date(), updatedAt: new Date(),
+      },
+    ]);
+    clientFindMany.mockResolvedValue([]);
+    tokenFindMany.mockResolvedValue([]);
+    const [conn] = await caller(ctx({ primaryWallet: ADDR })).listConnections({
+      requesterAddress: ADDR,
+    });
+    expect(conn.clientName).toBe("Unknown client");
+  });
+});
+
+describe("revokeConnection", () => {
+  it("deletes the grant and revokes its refresh tokens", async () => {
+    grantFindUnique.mockResolvedValue({ id: "g1", scopes: ["wallets:read"] });
+
+    const out = await caller(ctx({ primaryWallet: ADDR })).revokeConnection({
+      clientId: "c1",
+      requesterAddress: ADDR,
+    });
+
+    expect(out).toEqual({ ok: true, refreshTokensRevoked: 2 });
+    // Both writes go through one transaction — a deleted grant with live
+    // refresh tokens would let the client silently keep renewing.
+    expect(transaction).toHaveBeenCalled();
+    expect(tokenUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { subjectAddress: ADDR, clientId: "c1", revokedAt: null },
+      }),
+    );
+  });
+
+  it("refuses an address the wallet session does not hold", async () => {
+    // The body is attacker-controlled; only the session decides who you are.
+    await expect(
+      caller(ctx({ primaryWallet: ADDR })).revokeConnection({
+        clientId: "c1",
+        requesterAddress: OTHER,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  it("refuses when there is no wallet session at all", async () => {
+    await expect(
+      caller(ctx({ primaryWallet: null, sessionWallets: [] })).revokeConnection({
+        clientId: "c1",
+        requesterAddress: ADDR,
+      }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+
+  it("looks the grant up by (subject, client), not client alone", async () => {
+    grantFindUnique.mockResolvedValue({ id: "g1", scopes: [] });
+    await caller(ctx({ sessionWallets: [ADDR] })).revokeConnection({
+      clientId: "c1",
+      requesterAddress: ADDR,
+    });
+    expect(grantFindUnique).toHaveBeenCalledWith({
+      where: { subjectAddress_clientId: { subjectAddress: ADDR, clientId: "c1" } },
+    });
+  });
+
+  it("404s on a grant that does not exist", async () => {
+    grantFindUnique.mockResolvedValue(null);
+    await expect(
+      caller(ctx({ primaryWallet: ADDR })).revokeConnection({
+        clientId: "nope",
+        requesterAddress: ADDR,
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/src/__tests__/mcpRoute.test.ts
+++ b/src/__tests__/mcpRoute.test.ts
@@ -210,6 +210,13 @@ describe("POST /api/mcp — transport", () => {
     expect(challenge).toMatch(/^Bearer /);
     expect(challenge).toContain("resource_metadata=");
     expect(challenge).toContain("/.well-known/oauth-protected-resource");
+    // Clients request exactly the challenge's `scope`, not scopes_supported, so
+    // both read scopes must appear here or their tools are unreachable in
+    // practice. ballots:write is intentionally absent — the one write scope
+    // stays opt-in.
+    expect(challenge).toContain("wallets:read");
+    expect(challenge).toContain("governance:read");
+    expect(challenge).not.toContain("ballots:write");
   });
 
   it("serves tools/list on the modern protocol era", async () => {

--- a/src/components/pages/homepage/index.tsx
+++ b/src/components/pages/homepage/index.tsx
@@ -662,16 +662,65 @@ export function PageHomepage() {
               title="Connect an AI agent (MCP)"
               description="A Model Context Protocol endpoint, so Claude and other MCP clients can read your wallets directly."
             >
-              <div className="mt-4 space-y-3 text-sm">
-                <p className="text-muted-foreground">
-                  Endpoint: <code className="rounded bg-muted px-1">POST /api/mcp</code>. Add it to Claude Code with:
-                </p>
-                <pre className="overflow-x-auto rounded bg-muted p-3 text-xs">
-                  <code>claude mcp add --transport http mesh-multisig https://multisig.meshjs.dev/api/mcp</code>
-                </pre>
-                <p className="text-muted-foreground">
-                  You&apos;ll be sent to a consent screen to approve access with your wallet — no secrets to copy. The connection is <strong>read-only</strong> apart from governance ballot drafts: it can list wallets, pending transactions, UTxOs, proxies and active proposals, but it cannot sign transactions, move funds, or vote on-chain.
-                </p>
+              <div className="mt-4 space-y-5 text-sm">
+                <ol className="space-y-4">
+                  <li className="space-y-2">
+                    <div className="flex items-baseline gap-2">
+                      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium">1</span>
+                      <span className="font-medium">Add the server</span>
+                    </div>
+                    <p className="pl-7 text-muted-foreground">In Claude Code:</p>
+                    <pre className="ml-7 overflow-x-auto rounded bg-muted p-3 text-xs">
+                      <code>claude mcp add --transport http mesh-multisig https://multisig.meshjs.dev/api/mcp</code>
+                    </pre>
+                    <p className="pl-7 text-xs text-muted-foreground">
+                      For other clients, point them at{" "}
+                      <code className="rounded bg-muted px-1">https://multisig.meshjs.dev/api/mcp</code>{" "}
+                      over streamable HTTP. There is no API key to paste — the
+                      server advertises OAuth and the client discovers the rest.
+                    </p>
+                  </li>
+
+                  <li className="space-y-2">
+                    <div className="flex items-baseline gap-2">
+                      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium">2</span>
+                      <span className="font-medium">Authorize with your wallet</span>
+                    </div>
+                    <p className="pl-7 text-muted-foreground">
+                      Run <code className="rounded bg-muted px-1">/mcp</code> and
+                      pick the server. A consent screen opens here: connect your
+                      wallet, sign, and approve. You&apos;ll see exactly which
+                      client is asking and what it will be able to read.
+                    </p>
+                  </li>
+
+                  <li className="space-y-2">
+                    <div className="flex items-baseline gap-2">
+                      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium">3</span>
+                      <span className="font-medium">Ask it something</span>
+                    </div>
+                    <p className="pl-7 text-muted-foreground">
+                      &ldquo;List the pending transactions on our treasury&rdquo; ·
+                      &ldquo;What can we actually spend right now?&rdquo; ·
+                      &ldquo;Which active governance proposals still need a decision?&rdquo;
+                    </p>
+                  </li>
+                </ol>
+
+                <div className="rounded-lg border border-dashed p-3">
+                  <p className="text-xs text-muted-foreground">
+                    <strong className="text-foreground">Read-only, by design.</strong>{" "}
+                    A connected client can list wallets, pending transactions,
+                    spendable UTxOs, proxies and active proposals, and draft
+                    governance ballot rationales. It <strong>cannot</strong> sign
+                    transactions, move funds, or submit a vote on-chain. Manage or
+                    revoke connections any time under{" "}
+                    <Link href="/user" className="underline underline-offset-2">
+                      your profile
+                    </Link>
+                    .
+                  </p>
+                </div>
               </div>
             </CardUI>
           </div>

--- a/src/components/pages/user/McpConnectionsCard.tsx
+++ b/src/components/pages/user/McpConnectionsCard.tsx
@@ -1,0 +1,189 @@
+import { useState } from "react";
+import { Loader2, Plug, ShieldCheck, Trash2 } from "lucide-react";
+
+import CardUI from "@/components/ui/card-content";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import { MCP_SCOPE_DESCRIPTIONS, type McpScope } from "@/lib/mcp/scopes";
+import { useUserStore } from "@/lib/zustand/user";
+import { api } from "@/utils/api";
+
+/**
+ * AI clients connected over MCP.
+ *
+ * The counterpart to BotManagementCard: bots authenticate with a key the user
+ * mints here, MCP clients authenticate with an OAuth grant the user approves on
+ * the consent screen. Both need to be visible and revocable in one place, or a
+ * user has no way to see what they have connected.
+ */
+export default function McpConnectionsCard() {
+  const { toast } = useToast();
+  const userAddress = useUserStore((state) => state.userAddress);
+  const [pendingRevoke, setPendingRevoke] = useState<{
+    clientId: string;
+    clientName: string;
+  } | null>(null);
+
+  const utils = api.useUtils();
+  const { data: connections, isLoading } = api.mcp.listConnections.useQuery(
+    { requesterAddress: userAddress ?? "" },
+    { enabled: Boolean(userAddress) },
+  );
+
+  const revoke = api.mcp.revokeConnection.useMutation({
+    onSuccess: (result) => {
+      void utils.mcp.listConnections.invalidate();
+      setPendingRevoke(null);
+      toast({
+        title: "Connection revoked",
+        description:
+          result.refreshTokensRevoked > 0
+            ? `${result.refreshTokensRevoked} session${result.refreshTokensRevoked === 1 ? "" : "s"} ended. Any access token already issued stops working within the hour.`
+            : "The client will need your approval again to reconnect.",
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "Could not revoke",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  if (!userAddress) return null;
+
+  return (
+    <>
+      <CardUI
+        title="Connected AI clients"
+        description="Applications you have approved over the Model Context Protocol. Revoking one ends its access."
+        icon={Plug}
+      >
+        {isLoading ? (
+          <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Loading connections…
+          </div>
+        ) : !connections || connections.length === 0 ? (
+          <div className="flex flex-col gap-2 py-2">
+            <p className="text-sm text-muted-foreground">
+              No AI clients connected yet.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Point an MCP client at{" "}
+              <code className="rounded bg-muted px-1">/api/mcp</code> and approve
+              it when the consent screen appears. Connections are read-only apart
+              from governance ballot drafts — they cannot sign transactions, move
+              funds, or vote on-chain.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3 py-2">
+            {connections.map((c) => (
+              <div
+                key={c.clientId}
+                className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-start sm:justify-between"
+              >
+                <div className="flex min-w-0 flex-col gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <ShieldCheck className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="font-medium">{c.clientName}</span>
+                    {c.isMetadataUrl && (
+                      <Badge variant="secondary" title="Identified by a Client ID Metadata Document">
+                        verified metadata
+                      </Badge>
+                    )}
+                    <Badge variant={c.activeSessions > 0 ? "default" : "outline"}>
+                      {c.activeSessions > 0 ? "active" : "idle"}
+                    </Badge>
+                  </div>
+
+                  {/* The name is chosen by the client; the id is what we verified. */}
+                  <code className="block break-all text-xs text-muted-foreground">
+                    {c.clientId}
+                  </code>
+
+                  <ul className="flex flex-col gap-1">
+                    {c.scopes.map((scope) => (
+                      <li key={scope} className="text-xs text-muted-foreground">
+                        •{" "}
+                        {MCP_SCOPE_DESCRIPTIONS[scope as McpScope] ?? scope}
+                      </li>
+                    ))}
+                  </ul>
+
+                  <p className="text-xs text-muted-foreground">
+                    Approved {new Date(c.approvedAt).toLocaleDateString()}
+                    {c.grantedAddresses.length > 1 &&
+                      ` · covers ${c.grantedAddresses.length} wallets`}
+                  </p>
+                </div>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() =>
+                    setPendingRevoke({ clientId: c.clientId, clientName: c.clientName })
+                  }
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Revoke
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardUI>
+
+      <Dialog
+        open={pendingRevoke !== null}
+        onOpenChange={(open) => !open && setPendingRevoke(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Revoke {pendingRevoke?.clientName}?</DialogTitle>
+            <DialogDescription>
+              It will lose access to your wallets and need your approval again to
+              reconnect. An access token already issued keeps working until it
+              expires, within the hour.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingRevoke(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={revoke.isPending}
+              onClick={() =>
+                pendingRevoke &&
+                revoke.mutate({
+                  clientId: pendingRevoke.clientId,
+                  requesterAddress: userAddress,
+                })
+              }
+            >
+              {revoke.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Revoking…
+                </>
+              ) : (
+                "Revoke access"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/pages/api/mcp/README.md
+++ b/src/pages/api/mcp/README.md
@@ -61,6 +61,14 @@ Defined in `src/lib/mcp/scopes.ts` — the MCP spec deliberately defines no voca
 - `governance:read` — active governance proposals
 - `ballots:write` — ballot drafts, including rationale text (no on-chain vote)
 
+**What a client gets by default.** The `WWW-Authenticate` challenge advertises
+`wallets:read governance:read`. That is what clients actually request — Claude
+Code uses the challenge's `scope` rather than `scopes_supported` from the
+metadata document — so a scope omitted there is unreachable in practice, however
+well documented. `ballots:write` is deliberately excluded: it is the only scope
+that writes anything, so a client must ask for it explicitly (in Claude Code,
+pin `oauth.scopes` for the server). Re-authorize after changing it.
+
 These are intentionally *not* the `BOT_SCOPES` strings from `src/lib/auth/botKey.ts`.
 When a bot key authenticates, `mcpScopesForBot` projects one onto the other so a bot never
 gains MCP reach it lacks over REST — notably, `multisig:sign` maps to nothing.

--- a/src/pages/api/mcp/index.ts
+++ b/src/pages/api/mcp/index.ts
@@ -116,13 +116,28 @@ export default async function handler(
 }
 
 /**
+ * Scopes advertised in the 401 challenge — what a client asks for by default.
+ *
+ * This is load-bearing, not cosmetic. Claude Code (and clients following the
+ * same rule) request exactly the `scope` from the challenge rather than the
+ * full `scopes_supported` catalogue in the metadata document, so anything
+ * omitted here is unreachable in practice: the tools exist, but no grant ever
+ * covers them.
+ *
+ * Both read scopes are included so the read surface works out of the box.
+ * `ballots:write` is deliberately left out — it is the only scope that writes
+ * anything, so it stays opt-in for a client that asks for it explicitly.
+ */
+const CHALLENGE_SCOPES = ["wallets:read", "governance:read"] as const;
+
+/**
  * RFC 9728 challenge. `resource_metadata` is what lets an MCP client discover
  * the authorization server and start an OAuth flow unprompted.
  */
 function unauthorized(req: NextApiRequest, res: NextApiResponse) {
   res.setHeader(
     "WWW-Authenticate",
-    `Bearer resource_metadata="${protectedResourceMetadataUrl(req)}", scope="${formatMcpScopes(["wallets:read"])}"`,
+    `Bearer resource_metadata="${protectedResourceMetadataUrl(req)}", scope="${formatMcpScopes(CHALLENGE_SCOPES)}"`,
   );
   return jsonRpcError(res, 401, -32001, "Unauthorized");
 }

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -18,6 +18,7 @@ import useActiveWallet from "@/hooks/useActiveWallet";
 import useUTXOS from "@/hooks/useUTXOS";
 import { Badge } from "@/components/ui/badge";
 import BotManagementCard from "@/components/pages/user/BotManagementCard";
+import McpConnectionsCard from "@/components/pages/user/McpConnectionsCard";
 
 export const getServerSideProps = () => ({ props: {} });
 
@@ -357,6 +358,8 @@ export default function UserInfoPage() {
         </CardUI>
 
         <BotManagementCard />
+
+        <McpConnectionsCard />
 
         <CardUI
           title="Account Details"

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -11,6 +11,7 @@ import { contactRouter } from "./routers/contacts";
 import { botRouter } from "./routers/bot";
 import { governanceRouter } from "./routers/governance";
 import { notificationRouter } from "./routers/notifications";
+import { mcpRouter } from "./routers/mcp";
 
 /**
  * This is the primary router for your server.
@@ -24,6 +25,7 @@ export const appRouter = createTRPCRouter({
   signable: signableRouter,
   ballot: ballotRouter,
   proxy: proxyRouter,
+  mcp: mcpRouter,
   migration: migrationRouter,
   auth: authRouter,
   contact: contactRouter,

--- a/src/server/api/routers/mcp.ts
+++ b/src/server/api/routers/mcp.ts
@@ -1,0 +1,146 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
+import { audit } from "@/lib/observability/audit";
+
+/**
+ * MCP connections — the OAuth grants a user has approved for AI clients.
+ *
+ * Mirrors the bot-key surface in `bot.ts`: a user can see what they have
+ * connected and revoke it. Revocation is the important half — before this,
+ * approving a client through the consent screen was a one-way door, since
+ * nothing read `OAuthGrant` back.
+ */
+
+type SessionAddressContext = {
+  primaryWallet?: string | null;
+  sessionWallets?: string[];
+};
+
+/**
+ * Resolve the acting address from the wallet session, refusing anything the
+ * session does not actually hold. Same contract as `bot.ts` — a body-supplied
+ * address must never be trusted on its own, or one user could revoke another's
+ * connections.
+ */
+function requireSessionAddress(ctx: unknown, requesterAddress: string): string {
+  const c = ctx as SessionAddressContext;
+  const requested = requesterAddress.trim();
+  const sessionWallets = Array.isArray(c.sessionWallets) ? c.sessionWallets : [];
+
+  if (!c.primaryWallet && sessionWallets.length === 0) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Please authorize your active wallet first",
+    });
+  }
+  if (!requested) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Missing requester address" });
+  }
+  if (c.primaryWallet !== requested && !sessionWallets.includes(requested)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Address mismatch. Please authorize your currently connected wallet.",
+    });
+  }
+  return requested;
+}
+
+export const mcpRouter = createTRPCRouter({
+  /** Every AI client this address has approved, newest first. */
+  listConnections: protectedProcedure
+    .input(z.object({ requesterAddress: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const subjectAddress = requireSessionAddress(ctx, input.requesterAddress);
+
+      const grants = await ctx.db.oAuthGrant.findMany({
+        where: { subjectAddress },
+        orderBy: { updatedAt: "desc" },
+      });
+      if (grants.length === 0) return [];
+
+      const clientIds = grants.map((g) => g.clientId);
+      const [clients, tokens] = await Promise.all([
+        ctx.db.oAuthClient.findMany({ where: { clientId: { in: clientIds } } }),
+        ctx.db.oAuthRefreshToken.findMany({
+          where: { subjectAddress, clientId: { in: clientIds }, revokedAt: null },
+          select: { clientId: true, expiresAt: true },
+        }),
+      ]);
+
+      const clientById = new Map(clients.map((c) => [c.clientId, c]));
+      const now = Date.now();
+
+      return grants.map((grant) => {
+        const client = clientById.get(grant.clientId);
+        const live = tokens.filter(
+          (t) => t.clientId === grant.clientId && t.expiresAt.getTime() > now,
+        ).length;
+        return {
+          clientId: grant.clientId,
+          // Self-declared by whoever registered the client, so the UI shows the
+          // client id alongside it rather than treating this as an identity.
+          clientName: client?.clientName ?? "Unknown client",
+          clientUri: client?.clientUri ?? null,
+          /** True when the client id is a Client ID Metadata Document URL. */
+          isMetadataUrl: client?.isMetadataUrl ?? false,
+          scopes: grant.scopes,
+          grantedAddresses: grant.grantedAddresses,
+          approvedAt: grant.createdAt,
+          lastApprovedAt: grant.updatedAt,
+          /** Unexpired, unrevoked refresh tokens — i.e. whether it can still reconnect. */
+          activeSessions: live,
+        };
+      });
+    }),
+
+  /**
+   * Revoke a connection: drop the consent record and kill every refresh token
+   * issued under it.
+   *
+   * Outstanding access tokens are self-contained JWTs and stay valid until they
+   * expire (one hour), which is the normal trade-off for stateless verification.
+   * Removing the refresh tokens is what stops the client renewing, and dropping
+   * the grant means a fresh authorization needs consent again.
+   */
+  revokeConnection: protectedProcedure
+    .input(
+      z.object({
+        clientId: z.string().min(1),
+        requesterAddress: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const subjectAddress = requireSessionAddress(ctx, input.requesterAddress);
+
+      const grant = await ctx.db.oAuthGrant.findUnique({
+        where: {
+          subjectAddress_clientId: { subjectAddress, clientId: input.clientId },
+        },
+      });
+      if (!grant) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Connection not found" });
+      }
+
+      const [, revoked] = await ctx.db.$transaction([
+        ctx.db.oAuthGrant.delete({ where: { id: grant.id } }),
+        ctx.db.oAuthRefreshToken.updateMany({
+          where: { subjectAddress, clientId: input.clientId, revokedAt: null },
+          data: { revokedAt: new Date() },
+        }),
+      ]);
+
+      void audit(ctx.db, {
+        actorAddress: subjectAddress,
+        actorType: "user",
+        action: "mcp.connection.revoked",
+        resourceType: "oauth_grant",
+        resourceId: input.clientId,
+        outcome: "success",
+        metadata: { refreshTokensRevoked: revoked.count, scopes: grant.scopes },
+      });
+
+      return { ok: true, refreshTokensRevoked: revoked.count };
+    }),
+});


### PR DESCRIPTION
Follow-up to #357, from connecting a real client to preprod and finding two gaps.

## Connections are now visible and revocable

Approving an AI client on the consent screen was a **one-way door**: the `OAuthGrant` row was written but never read back, so there was no way to see what was connected and no way to disconnect it.

Adds a **"Connected AI clients"** card to the profile, next to the bot-key card it mirrors — bots authenticate with a key minted there, MCP clients with an OAuth grant approved on the consent screen. Each entry shows:

- the client name **and the client id it was actually verified as** (the name is self-declared by whoever registered the client, so it isn't identity)
- a `verified metadata` badge for CIMD clients
- the granted scopes in plain language
- whether a session is still live

Revoking drops the grant and revokes every refresh token under it **in one transaction** — a deleted grant with live refresh tokens would let the client keep renewing silently. Access tokens already issued are self-contained JWTs and stay valid until they expire within the hour; the confirmation dialog says so rather than implying an instant cutoff.

## Fixes: two tools were unreachable

The first live connection came back with **only `wallets:read`**, so `governance_list_active_proposals` and `ballot_upsert` never appeared in the client's tool list.

Cause: the 401 challenge advertised `scope="wallets:read"`, and clients request exactly the challenge's `scope` rather than `scopes_supported` from the metadata document. Anything omitted there is unreachable in practice, however well documented.

The challenge now advertises both read scopes. `ballots:write` stays out deliberately — it's the only scope that writes anything, so a client must ask for it explicitly. Pinned by a test so it can't drift back.

## Landing page

The "Connect an AI agent" card is now three numbered setup steps — add the server, authorize with your wallet, ask it something — plus a read-only callout linking to the profile.

## Verification

`tsc --noEmit` clean, `npm run build` green, 801 + 76 tests. Nine new tests for the router, covering the authorization boundary: revoke refuses an address the wallet session doesn't hold, refuses with no session at all, looks the grant up by `(subject, client)` rather than client alone, and 404s on a missing grant. Landing section verified in a browser.

**Not verified visually**: the profile card itself needs a wallet session *and* a database, so I couldn't render it locally — it self-hides without an address (confirmed no tRPC request fires). Its router is unit-tested, and the card will have real data to show on preprod.

Note the router tests live in the ESM jest project: importing a tRPC router pulls `superjson`, which is ESM-only and cannot load in the CJS project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)